### PR TITLE
[Feature] Schedule 수정 API 구현

### DIFF
--- a/src/main/java/com/wegotoo/api/schedule/DetailedPlanController.java
+++ b/src/main/java/com/wegotoo/api/schedule/DetailedPlanController.java
@@ -3,8 +3,11 @@ package com.wegotoo.api.schedule;
 import com.wegotoo.api.ApiResponse;
 import com.wegotoo.api.schedule.request.DetailedPlanCreateRequest;
 import com.wegotoo.application.schedule.DetailedPlanService;
+import com.wegotoo.application.schedule.request.DetailedPlanEditRequest;
+import com.wegotoo.application.schedule.request.MovePlanRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,8 +20,24 @@ public class DetailedPlanController {
     private final DetailedPlanService detailedPlanService;
 
     @PostMapping("/v1/schedule-details/{scheduleDetailsId}/detailed-plans")
-    public ApiResponse<Void> writeDetailedPlan(@PathVariable("scheduleDetailsId") Long scheduleDetailsId, @RequestBody @Valid DetailedPlanCreateRequest request) {
+    public ApiResponse<Void> writeDetailedPlan(@PathVariable("scheduleDetailsId") Long scheduleDetailsId,
+                                               @RequestBody @Valid DetailedPlanCreateRequest request) {
         detailedPlanService.writeDetailedPlan(scheduleDetailsId, 0L, request.toService());
         return ApiResponse.ok();
     }
+
+    @PatchMapping("/v1/detailed-plans/{detailedPlanId}")
+    public ApiResponse<Void> editDetailedPlan(@PathVariable("detailedPlanId") Long detailedPlanId,
+                                              @RequestBody @Valid DetailedPlanEditRequest request) {
+        detailedPlanService.editDetailedPlan(detailedPlanId, 0L, request.toService());
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/v1/detailed-plans/{detailedPlanId}/move")
+    public ApiResponse<Void> movePlan(@PathVariable("detailedPlanId") Long detailedPlanId,
+                                      @RequestBody MovePlanRequest request) {
+        detailedPlanService.movePlan(detailedPlanId, 0L, request.isMoveUp());
+        return ApiResponse.ok();
+    }
+
 }

--- a/src/main/java/com/wegotoo/api/schedule/ScheduleController.java
+++ b/src/main/java/com/wegotoo/api/schedule/ScheduleController.java
@@ -3,8 +3,11 @@ package com.wegotoo.api.schedule;
 import com.wegotoo.api.ApiResponse;
 import com.wegotoo.api.schedule.request.ScheduleCreateRequest;
 import com.wegotoo.application.schedule.ScheduleService;
+import com.wegotoo.api.schedule.request.ScheduleEditRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +22,12 @@ public class ScheduleController {
     public ApiResponse<Void> createSchedule(@RequestBody @Valid ScheduleCreateRequest request) {
         //todo 로그인 기능 구현될 시 0L 대신 로그인 유저 정보 값으로 변경 예정
         scheduleService.createSchedule(0L ,request.toService());
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/v1/schedules/{scheduleId}")
+    public ApiResponse<Void> editSchedule(@PathVariable("scheduleId") Long scheduleId, @RequestBody @Valid ScheduleEditRequest request) {
+        scheduleService.editSchedule(0L, scheduleId, request.toService());
         return ApiResponse.ok();
     }
 

--- a/src/main/java/com/wegotoo/api/schedule/request/DetailedPlanCreateRequest.java
+++ b/src/main/java/com/wegotoo/api/schedule/request/DetailedPlanCreateRequest.java
@@ -15,9 +15,7 @@ public class DetailedPlanCreateRequest {
     @NotNull(message = "여행 일자는 필수입니다.")
     private LocalDate date;
 
-    @NotNull(message = "타입은 필수입니다.")
-    private String type;
-
+    @NotNull(message = "장소는 필수입니다.")
     private String name;
 
     @NotNull(message = "위도는 필수입니다.")
@@ -27,10 +25,9 @@ public class DetailedPlanCreateRequest {
     private Double longitude;
 
     @Builder
-    private DetailedPlanCreateRequest(LocalDate date, String type, String name, Double latitude,
+    private DetailedPlanCreateRequest(LocalDate date, String name, Double latitude,
                                       Double longitude) {
         this.date = date;
-        this.type = type;
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -39,7 +36,6 @@ public class DetailedPlanCreateRequest {
     public DetailedPlanCreateServiceRequest toService() {
         return DetailedPlanCreateServiceRequest.builder()
                 .date(date)
-                .type(Type.fromKey(type))
                 .name(name)
                 .latitude(latitude)
                 .longitude(longitude)

--- a/src/main/java/com/wegotoo/api/schedule/request/ScheduleEditRequest.java
+++ b/src/main/java/com/wegotoo/api/schedule/request/ScheduleEditRequest.java
@@ -1,0 +1,40 @@
+package com.wegotoo.api.schedule.request;
+
+import com.wegotoo.application.schedule.request.ScheduleEditServiceRequest;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ScheduleEditRequest {
+
+    private String title;
+
+    private String city;
+
+    @NotNull(message = "여행 시작 일은 필수입니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "여행 종료 일은 필수입니다.")
+    private LocalDate endDate;
+
+    @Builder
+    private ScheduleEditRequest(String title, String city, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.city = city;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public ScheduleEditServiceRequest toService() {
+        return ScheduleEditServiceRequest.builder()
+                .title(title)
+                .city(city)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+}

--- a/src/main/java/com/wegotoo/application/schedule/ScheduleService.java
+++ b/src/main/java/com/wegotoo/application/schedule/ScheduleService.java
@@ -3,9 +3,12 @@ package com.wegotoo.application.schedule;
 import static com.wegotoo.exception.ErrorCode.*;
 
 import com.wegotoo.application.schedule.request.ScheduleCreateServiceRequest;
+import com.wegotoo.application.schedule.request.ScheduleEditServiceRequest;
+import com.wegotoo.domain.schedule.DetailedPlan;
 import com.wegotoo.domain.schedule.Schedule;
 import com.wegotoo.domain.schedule.ScheduleDetails;
 import com.wegotoo.domain.schedule.ScheduleGroup;
+import com.wegotoo.domain.schedule.repository.DetailPlanRepository;
 import com.wegotoo.domain.schedule.repository.ScheduleDetailsRepository;
 import com.wegotoo.domain.schedule.repository.ScheduleGroupRepository;
 import com.wegotoo.domain.schedule.repository.ScheduleRepository;
@@ -13,7 +16,6 @@ import com.wegotoo.domain.user.User;
 import com.wegotoo.domain.user.repository.UserRepository;
 import com.wegotoo.exception.BusinessException;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class ScheduleService {
     private final UserRepository userRepository;
     private final ScheduleGroupRepository scheduleGroupRepository;
     private final ScheduleDetailsRepository scheduleDetailsRepository;
+    private final DetailPlanRepository detailPlanRepository;
 
     @Transactional
     public void createSchedule(Long userId, ScheduleCreateServiceRequest request) {
@@ -46,6 +49,63 @@ public class ScheduleService {
                 .stream().map(date -> ScheduleDetails.create(date, schedule))
                 .toList();
         scheduleDetailsRepository.saveAll(scheduleDetailsList);
+    }
+
+    @Transactional
+    public void editSchedule(Long userId, Long scheduleId, ScheduleEditServiceRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new BusinessException(SCHEDULE_NOT_FOUND));
+
+        validateUserHasAccessToSchedule(user.getId(), schedule.getId());
+
+        editScheduleDetails(schedule, request.getStartDate(), request.getEndDate());
+
+        schedule.edit(request.getTitle(), request.getCity(), request.getStartDate(), request.getEndDate(),
+                request.totalTravelDays());
+    }
+
+    private void editScheduleDetails(Schedule schedule, LocalDate newStartDate, LocalDate newEndDate) {
+        List<ScheduleDetails> existingDetails = scheduleDetailsRepository.findBySchedule(schedule);
+
+        List<LocalDate> existingDates = existingDetails.stream()
+                .map(ScheduleDetails::getDate)
+                .toList();
+
+        List<LocalDate> newDates = getDatesBetween(newStartDate, newEndDate);
+
+        List<LocalDate> datesToAdd = newDates.stream()
+                .filter(date -> isDateContain(date, existingDates))
+                .toList();
+
+        List<ScheduleDetails> detailsToRemove = existingDetails.stream()
+                .filter(detail -> isDateContain(detail.getDate(), newDates))
+                .toList();
+
+        List<DetailedPlan> detailedPlans = detailPlanRepository.findByScheduleDetails(detailsToRemove);
+        detailPlanRepository.deleteAll(detailedPlans);
+
+        scheduleDetailsRepository.deleteAll(detailsToRemove);
+
+        List<ScheduleDetails> detailsToAdd = datesToAdd.stream()
+                .map(date -> ScheduleDetails.create(date, schedule))
+                .toList();
+
+        scheduleDetailsRepository.saveAll(detailsToAdd);
+    }
+
+    private static boolean isDateContain(LocalDate date, List<LocalDate> existingDates) {
+        return !existingDates.contains(date);
+    }
+
+    private void validateUserHasAccessToSchedule(Long userId, Long scheduleId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        scheduleGroupRepository.findByUserIdAndScheduleId(user.getId(), scheduleId)
+                .orElseThrow(() -> new BusinessException(UNAUTHORIZED_REQUEST));
     }
 
     private List<LocalDate> getDatesBetween(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/wegotoo/application/schedule/ScheduleService.java
+++ b/src/main/java/com/wegotoo/application/schedule/ScheduleService.java
@@ -61,20 +61,13 @@ public class ScheduleService {
 
         validateUserHasAccessToSchedule(user.getId(), schedule.getId());
 
-        editScheduleDetails(schedule, request.getStartDate(), request.getEndDate());
-
-        schedule.edit(request.getTitle(), request.getCity(), request.getStartDate(), request.getEndDate(),
-                request.totalTravelDays());
-    }
-
-    private void editScheduleDetails(Schedule schedule, LocalDate newStartDate, LocalDate newEndDate) {
         List<ScheduleDetails> existingDetails = scheduleDetailsRepository.findBySchedule(schedule);
 
         List<LocalDate> existingDates = existingDetails.stream()
                 .map(ScheduleDetails::getDate)
                 .toList();
 
-        List<LocalDate> newDates = getDatesBetween(newStartDate, newEndDate);
+        List<LocalDate> newDates = getDatesBetween(request.getStartDate(), request.getEndDate());
 
         List<LocalDate> datesToAdd = newDates.stream()
                 .filter(date -> isDateContain(date, existingDates))
@@ -94,6 +87,9 @@ public class ScheduleService {
                 .toList();
 
         scheduleDetailsRepository.saveAll(detailsToAdd);
+
+        schedule.edit(request.getTitle(), request.getCity(), request.getStartDate(), request.getEndDate(),
+                request.totalTravelDays());
     }
 
     private static boolean isDateContain(LocalDate date, List<LocalDate> existingDates) {

--- a/src/main/java/com/wegotoo/application/schedule/request/DetailedPlanEditRequest.java
+++ b/src/main/java/com/wegotoo/application/schedule/request/DetailedPlanEditRequest.java
@@ -1,0 +1,37 @@
+package com.wegotoo.application.schedule.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DetailedPlanEditRequest {
+
+    @NotNull(message = "지역은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private Double longitude;
+
+    @Builder
+    private DetailedPlanEditRequest(String name, Double latitude, Double longitude) {
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+
+    public DetailedPlanEditServiceRequest toService() {
+        return DetailedPlanEditServiceRequest.builder()
+                .name(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wegotoo/application/schedule/request/DetailedPlanEditServiceRequest.java
+++ b/src/main/java/com/wegotoo/application/schedule/request/DetailedPlanEditServiceRequest.java
@@ -1,22 +1,18 @@
 package com.wegotoo.application.schedule.request;
 
-import com.wegotoo.domain.schedule.Type;
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class DetailedPlanCreateServiceRequest {
+public class DetailedPlanEditServiceRequest {
 
-    private LocalDate date;
     private String name;
     private Double latitude;
     private Double longitude;
 
     @Builder
-    private DetailedPlanCreateServiceRequest(LocalDate date, String name, Double latitude,
-                                             Double longitude) {
-        this.date = date;
+    private DetailedPlanEditServiceRequest(String name, Double latitude, Double longitude) {
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;

--- a/src/main/java/com/wegotoo/application/schedule/request/MovePlanRequest.java
+++ b/src/main/java/com/wegotoo/application/schedule/request/MovePlanRequest.java
@@ -1,0 +1,18 @@
+package com.wegotoo.application.schedule.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MovePlanRequest {
+
+    private boolean isMoveUp;
+
+    @Builder
+    private MovePlanRequest(boolean isMoveUp) {
+        this.isMoveUp = isMoveUp;
+    }
+
+}

--- a/src/main/java/com/wegotoo/application/schedule/request/ScheduleEditServiceRequest.java
+++ b/src/main/java/com/wegotoo/application/schedule/request/ScheduleEditServiceRequest.java
@@ -1,0 +1,31 @@
+package com.wegotoo.application.schedule.request;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ScheduleEditServiceRequest {
+
+    private String title;
+
+    private String city;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Builder
+    private ScheduleEditServiceRequest(String title, String city, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.city = city;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public long totalTravelDays() {
+        return ChronoUnit.DAYS.between(startDate, endDate) + 1;
+    }
+
+}

--- a/src/main/java/com/wegotoo/domain/schedule/DetailedPlan.java
+++ b/src/main/java/com/wegotoo/domain/schedule/DetailedPlan.java
@@ -25,10 +25,6 @@ public class DetailedPlan {
     @Column(name = "detailed_plan_id")
     private Long Id;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "detailed_plan_type",  nullable = false)
-    private Type type;
-
     @Column(name = "detailed_plan_name")
     private String name;
 
@@ -46,9 +42,8 @@ public class DetailedPlan {
     private ScheduleDetails scheduleDetails;
 
     @Builder
-    private DetailedPlan(Type type, String name, Double latitude, Double longitude, Long sequence,
+    private DetailedPlan(String name, Double latitude, Double longitude, Long sequence,
                          ScheduleDetails scheduleDetails) {
-        this.type = type;
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;
@@ -56,15 +51,24 @@ public class DetailedPlan {
         this.scheduleDetails = scheduleDetails;
     }
 
-    public static DetailedPlan create(Type type, String name, Double latitude, Double longitude, Long sequence,
+    public static DetailedPlan create(String name, Double latitude, Double longitude, Long sequence,
                                       ScheduleDetails scheduleDetails) {
         return DetailedPlan.builder()
-                .type(type)
                 .name(name)
                 .latitude(latitude)
                 .longitude(longitude)
                 .sequence(sequence + 1)
                 .scheduleDetails(scheduleDetails)
                 .build();
+    }
+
+    public void edit(String name, Double latitude, Double longitude) {
+        this.name = name != null ? name : this.name;
+        this.latitude = latitude != null ? latitude : this.latitude;
+        this.longitude = longitude != null ? longitude : this.longitude;
+    }
+
+    public void movePlan(Long sequence) {
+        this.sequence = sequence;
     }
 }

--- a/src/main/java/com/wegotoo/domain/schedule/DetailedPlan.java
+++ b/src/main/java/com/wegotoo/domain/schedule/DetailedPlan.java
@@ -1,5 +1,6 @@
 package com.wegotoo.domain.schedule;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cascade;
 
 @Getter
 @Entity

--- a/src/main/java/com/wegotoo/domain/schedule/Schedule.java
+++ b/src/main/java/com/wegotoo/domain/schedule/Schedule.java
@@ -55,4 +55,11 @@ public class Schedule {
                 .build();
     }
 
+    public void edit(String title, String city, LocalDate startDate, LocalDate endDate, long totalTravelDays) {
+        this.title = title != null ? title : this.title;
+        this.city = city != null ? city : this.city;
+        this.startDate = startDate != null ? startDate : this.startDate;
+        this.endDate = endDate != null ? endDate : this.endDate;
+        this.totalTravelDays = totalTravelDays;
+    }
 }

--- a/src/main/java/com/wegotoo/domain/schedule/repository/DetailPlanRepository.java
+++ b/src/main/java/com/wegotoo/domain/schedule/repository/DetailPlanRepository.java
@@ -1,8 +1,12 @@
 package com.wegotoo.domain.schedule.repository;
 
 import com.wegotoo.domain.schedule.DetailedPlan;
+import com.wegotoo.domain.schedule.ScheduleDetails;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +15,8 @@ public interface DetailPlanRepository extends JpaRepository<DetailedPlan, Long>,
     Optional<DetailedPlan> findTopBySequenceLessThanOrderBySequenceDesc(Long sequence);
 
     Optional<DetailedPlan> findTopBySequenceGreaterThanOrderBySequenceAsc(Long sequence);
+
+    @Query("SELECT dp FROM DetailedPlan dp JOIN FETCH dp.scheduleDetails sd WHERE sd IN :scheduleDetails")
+    List<DetailedPlan> findByScheduleDetails(@Param("scheduleDetails") List<ScheduleDetails> scheduleDetails);
+
 }

--- a/src/main/java/com/wegotoo/domain/schedule/repository/DetailPlanRepository.java
+++ b/src/main/java/com/wegotoo/domain/schedule/repository/DetailPlanRepository.java
@@ -1,10 +1,14 @@
 package com.wegotoo.domain.schedule.repository;
 
 import com.wegotoo.domain.schedule.DetailedPlan;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DetailPlanRepository extends JpaRepository<DetailedPlan, Long>, DetailPlanRepositoryCustom {
 
+    Optional<DetailedPlan> findTopBySequenceLessThanOrderBySequenceDesc(Long sequence);
+
+    Optional<DetailedPlan> findTopBySequenceGreaterThanOrderBySequenceAsc(Long sequence);
 }

--- a/src/main/java/com/wegotoo/domain/schedule/repository/ScheduleDetailsRepository.java
+++ b/src/main/java/com/wegotoo/domain/schedule/repository/ScheduleDetailsRepository.java
@@ -3,8 +3,11 @@ package com.wegotoo.domain.schedule.repository;
 import com.wegotoo.domain.schedule.Schedule;
 import com.wegotoo.domain.schedule.ScheduleDetails;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +16,7 @@ public interface ScheduleDetailsRepository extends JpaRepository<ScheduleDetails
     ScheduleDetails findByDateAndSchedule(LocalDate date, Schedule schedule);
 
     Optional<ScheduleDetails> findByIdAndDate(Long scheduleDetailsId, LocalDate date);
+
+    @Query("SELECT sd FROM ScheduleDetails sd JOIN FETCH sd.schedule WHERE sd.schedule = :schedule")
+    List<ScheduleDetails> findBySchedule(@Param("schedule") Schedule schedule);
 }

--- a/src/main/java/com/wegotoo/exception/ErrorCode.java
+++ b/src/main/java/com/wegotoo/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     UNAUTHORIZED_REQUEST(400, "권한이 없는 사용자입니다."),
     INVALID_PARAMS_VALUE(400, "유효하지 않은 파라미터 입니다."),
     SCHEDULE_DETAIL_NOT_FOUND(404, "세부 일정을 찾을 수 없습니다."),
-    DETAILED_PLAN_NOT_FOUND(404, "세부 계획을 찾을 수 없습니다.");
+    DETAILED_PLAN_NOT_FOUND(404, "세부 계획을 찾을 수 없습니다."),
+    CANNOT_MOVE_SEQUENCE(500, "순서를 이동할 수 없습니다.");
 
     private final int code;
     private final String message;

--- a/src/test/java/com/wegotoo/api/schedule/DetailedPlanControllerTest.java
+++ b/src/test/java/com/wegotoo/api/schedule/DetailedPlanControllerTest.java
@@ -1,6 +1,7 @@
 package com.wegotoo.api.schedule;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -9,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wegotoo.api.schedule.request.DetailedPlanCreateRequest;
 import com.wegotoo.application.schedule.DetailedPlanService;
+import com.wegotoo.application.schedule.request.DetailedPlanEditRequest;
+import com.wegotoo.application.schedule.request.MovePlanRequest;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +42,6 @@ class DetailedPlanControllerTest {
         // given
         DetailedPlanCreateRequest request = DetailedPlanCreateRequest.builder()
                 .date(DATE)
-                .type("TYPE_LOCATION")
                 .name("제주공항")
                 .latitude(11.1)
                 .longitude(11.1)
@@ -64,7 +66,6 @@ class DetailedPlanControllerTest {
     void validateDetailedPlanDate() throws Exception {
         // given
         DetailedPlanCreateRequest request = DetailedPlanCreateRequest.builder()
-                .type("TYPE_LOCATION")
                 .name("제주공항")
                 .latitude(11.1)
                 .longitude(11.1)
@@ -84,12 +85,11 @@ class DetailedPlanControllerTest {
     }
 
     @Test
-    @DisplayName("세부일정의 세부계획을 작성할 때 타입을 입력하지 않으면 예외가 발생한다.")
-    void validateDetailedPlanType() throws Exception {
+    @DisplayName("세부일정의 세부계획을 작성할 때 장소를 입력하지 않으면 예외가 발생한다.")
+    void validateDetailedPlanLocal() throws Exception {
         // given
         DetailedPlanCreateRequest request = DetailedPlanCreateRequest.builder()
                 .date(DATE)
-                .name("제주공항")
                 .latitude(11.1)
                 .longitude(11.1)
                 .build();
@@ -104,7 +104,7 @@ class DetailedPlanControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.message").value("타입은 필수입니다."));
+                .andExpect(jsonPath("$.message").value("장소는 필수입니다."));
     }
 
     @Test
@@ -113,7 +113,6 @@ class DetailedPlanControllerTest {
         // given
         DetailedPlanCreateRequest request = DetailedPlanCreateRequest.builder()
                 .date(DATE)
-                .type("TYPE_LOCATION")
                 .name("제주공항")
                 .longitude(11.1)
                 .build();
@@ -137,7 +136,6 @@ class DetailedPlanControllerTest {
         // given
         DetailedPlanCreateRequest request = DetailedPlanCreateRequest.builder()
                 .date(DATE)
-                .type("TYPE_LOCATION")
                 .name("제주공항")
                 .latitude(11.1)
                 .build();
@@ -153,6 +151,118 @@ class DetailedPlanControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("경도는 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("세부계획의 내용을 수정하는 API를 호출한다.")
+    void editDetailedPlan() throws Exception {
+        // given
+        DetailedPlanEditRequest request = DetailedPlanEditRequest.builder()
+                .name("제주공항")
+                .latitude(11.1)
+                .longitude(11.1)
+                .build();
+
+        Long detailedPlanId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/detailed-plans/{detailedPlanId}", detailedPlanId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @Test
+    @DisplayName("세부계획의 내용을 수정할 때 지역 이름을 넣지 않으면 예외가 발생한다.")
+    void validateEditDetailedPlanLocal() throws Exception {
+        // given
+        DetailedPlanEditRequest request = DetailedPlanEditRequest.builder()
+                .latitude(11.1)
+                .longitude(11.1)
+                .build();
+
+        Long detailedPlanId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/detailed-plans/{detailedPlanId}", detailedPlanId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("지역은 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("세부계획의 내용을 수정할 때 지역 위도를 넣지 않으면 예외가 발생한다.")
+    void validateEditDetailedPlanLatitude() throws Exception {
+        // given
+        DetailedPlanEditRequest request = DetailedPlanEditRequest.builder()
+                .name("제주공항")
+                .longitude(11.1)
+                .build();
+
+        Long detailedPlanId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/detailed-plans/{detailedPlanId}", detailedPlanId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("위도는 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("세부계획의 내용을 수정할 때 지역 경도를 넣지 않으면 예외가 발생한다.")
+    void validateEditDetailedPlanLongitude() throws Exception {
+        // given
+        DetailedPlanEditRequest request = DetailedPlanEditRequest.builder()
+                .name("제주공항")
+                .latitude(11.1)
+                .build();
+
+        Long detailedPlanId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/detailed-plans/{detailedPlanId}", detailedPlanId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("경도는 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("세부계획의 순서를 변경하는 API를 호출한다.")
+    void movePlan() throws Exception {
+        // given
+        MovePlanRequest request = MovePlanRequest.builder()
+                .isMoveUp(true)
+                .build();
+
+        Long detailedPlanId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/detailed-plans/{detailedPlanId}/move", detailedPlanId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
     }
 
 }

--- a/src/test/java/com/wegotoo/api/schedule/ScheduleControllerTest.java
+++ b/src/test/java/com/wegotoo/api/schedule/ScheduleControllerTest.java
@@ -1,6 +1,7 @@
 package com.wegotoo.api.schedule;
 
 import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -8,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wegotoo.api.schedule.request.ScheduleCreateRequest;
+import com.wegotoo.api.schedule.request.ScheduleEditRequest;
 import com.wegotoo.application.schedule.ScheduleService;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -106,6 +108,77 @@ class ScheduleControllerTest {
 
         // when // then
         mockMvc.perform(post("/v1/schedules")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("여행 종료 일은 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("사용자가 일정 수정 API를 호출한다.")
+    void editSchedule() throws Exception {
+        // given
+        ScheduleEditRequest request = ScheduleEditRequest.builder()
+                .title("제주도 여행")
+                .city("제주도")
+                .startDate(START_DATE)
+                .endDate(END_DATE)
+                .build();
+
+        Long scheduleId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/schedules/{scheduleId}", scheduleId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @Test
+    @DisplayName("사용자가 수정할 때 여행 시작 일을 작성하지 않으면 예외가 발생한다.")
+    void validateEditStartDate() throws Exception {
+        // given
+        ScheduleEditRequest request = ScheduleEditRequest.builder()
+                .title("제주도 여행")
+                .city("제주도")
+                .endDate(END_DATE)
+                .build();
+
+        Long scheduleId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/schedules/{scheduleId}", scheduleId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("여행 시작 일은 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("사용자 수정할 때 여행 종료 일을 작성하지 않으면 예외가 발생한다.")
+    void validateEditEndDate() throws Exception {
+        // given
+        ScheduleEditRequest request = ScheduleEditRequest.builder()
+                .title("제주도 여행")
+                .city("제주도")
+                .startDate(START_DATE)
+                .build();
+
+        Long scheduleId = 1L;
+
+        // when // then
+        mockMvc.perform(patch("/v1/schedules/{scheduleId}", scheduleId)
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(APPLICATION_JSON)
                 )

--- a/src/test/java/com/wegotoo/application/schedule/MemoServiceTest.java
+++ b/src/test/java/com/wegotoo/application/schedule/MemoServiceTest.java
@@ -163,7 +163,6 @@ class MemoServiceTest {
     private DetailedPlan getDetailedPlan(ScheduleDetails scheduleDetails) {
         return DetailedPlan.builder()
                 .scheduleDetails(scheduleDetails)
-                .type(Type.LOCATION)
                 .name("제주공항")
                 .latitude(11.1)
                 .longitude(11.1)

--- a/src/test/java/com/wegotoo/domain/schedule/repository/DetailPlanRepositoryImplTest.java
+++ b/src/test/java/com/wegotoo/domain/schedule/repository/DetailPlanRepositoryImplTest.java
@@ -85,7 +85,6 @@ class DetailPlanRepositoryImplTest {
 
         List<DetailedPlan> plans = IntStream.range(1, 4)
                 .mapToObj(i -> DetailedPlan.builder()
-                        .type(Type.LOCATION)
                         .name("제주도 " + i)
                         .scheduleDetails(scheduleDetails)
                         .latitude(11.1)


### PR DESCRIPTION
## 💡 연관된 이슈
close #9 

## 📝 작업 내용
* Schedule 수정 API 구현
* Schedule 수정 API 테스트 코드 작성
* DetailedPlan 수정 API 구현
* DetailedPlan 수정 API 테스트 코드 작성

## 💬 리뷰 요구 사항
* 세부 일정의 순서를 변경하는 로직
```
    @Transactional
    public void movePlan(Long detailedPlanId, Long userId, boolean isMoveUp) {
        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(USER_NOT_FOUND));

        DetailedPlan detailedPlan = detailPlanRepository.findById(detailedPlanId)
                .orElseThrow(() -> new BusinessException(DETAILED_PLAN_NOT_FOUND));

        ScheduleDetails scheduleDetails = detailedPlan.getScheduleDetails();
        Schedule schedule = scheduleDetails.getSchedule();

        validateUserHasAccessToSchedule(user.getId(), schedule.getId());

        DetailedPlan swapPlan = isMoveUp(detailedPlan, isMoveUp);

       // 이 부분에서 순서를 변경합니다.
        Long tempSequence = detailedPlan.getSequence();
        detailedPlan.movePlan(swapPlan.getSequence());
        swapPlan.movePlan(tempSequence);
    }
```
```java
    private DetailedPlan isMoveUp(DetailedPlan detailedPlan, boolean isMoveUp) {
        if (isMoveUp) {
             // 현재 계획보다 큰 sequence 값을 가진 다음 계획을 가져옵니다.
            // 예를 들어, 현재 계획 A의 sequence가 1이고, 계획 B의 sequence가 2라면, 
            // 이 쿼리는 sequence가 2인 계획 B를 반환합니다. 
            // 이는 계획의 순서를 변경할 때 사용되며, 만약 더 큰 sequence 값을 가진 계획이 없다면 
            // BusinessException(CANNOT_MOVE_SEQUENCE)을 발생시킵니다.
            // 즉, 이동할 수 없는 상황(마지막 계획인 경우)에서는 예외를 던집니다.
            return detailPlanRepository.findTopBySequenceGreaterThanOrderBySequenceAsc(
                            detailedPlan.getSequence())
                    .orElseThrow(() -> new BusinessException(CANNOT_MOVE_SEQUENCE));
        }
        return detailPlanRepository.findTopBySequenceLessThanOrderBySequenceDesc(
                        detailedPlan.getSequence())
                .orElseThrow(() -> new BusinessException(CANNOT_MOVE_SEQUENCE));
    }
```

* 여행 일정의 제목, 기간을 변경하는 로직
> 현재 이 로직에 대해 고민이 많습니다. 원래 계획은 여행 일정이 변경되더라도 세부 계획은 변동이 없거나, 2박 3일에서 1박 2일로 변경될 경우 3일차 계획이 2일차 계획으로 합쳐지도록 만들고자 했습니다.그러나 연관관계를 잘못 설정한 탓인지,,, 도무지 생각이 나지 않아 일단 시간 관계상 세부 계획은 삭제 되도록 설계했습니다.
```java
@Transactional
    public void editSchedule(Long userId, Long scheduleId, ScheduleEditServiceRequest request) {
        User user = userRepository.findById(userId)
                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));

        Schedule schedule = scheduleRepository.findById(scheduleId)
                .orElseThrow(() -> new BusinessException(SCHEDULE_NOT_FOUND));

        validateUserHasAccessToSchedule(user.getId(), schedule.getId());

        editScheduleDetails(schedule, request.getStartDate(), request.getEndDate());

        schedule.edit(request.getTitle(), request.getCity(), request.getStartDate(), request.getEndDate(),
                request.totalTravelDays());
    }
```
```java
/**
 * 여행 기간 변경에 따라 세부 일정을 동적으로 추가/삭제하는 메서드.
 * 
 * 1. 기존 세부 일정 목록을 가져와서, 새로운 날짜 범위와 비교합니다.
 * 2. 새로운 날짜에 포함되지 않는 세부 일정은 삭제하고, 기존에 없던 날짜는 추가합니다.
 * 3. 세부 일정에 연관된 세부 계획(DetailedPlan)도 함께 삭제 처리합니다.
 *
 * @param schedule      수정할 일정 객체
 * @param newStartDate  새로 변경된 여행 시작일
 * @param newEndDate    새로 변경된 여행 종료일
 */
private void editScheduleDetails(Schedule schedule, LocalDate newStartDate, LocalDate newEndDate) {
    // 해당 일정의 기존 세부 일정 목록을 조회
    List<ScheduleDetails> existingDetails = scheduleDetailsRepository.findBySchedule(schedule);

    // 기존 세부 일정들의 날짜 목록 추출
    List<LocalDate> existingDates = existingDetails.stream()
            .map(ScheduleDetails::getDate)
            .toList();

    // 새로운 일정에 맞춘 날짜 목록 추출
    List<LocalDate> newDates = getDatesBetween(newStartDate, newEndDate);

    // 새로운 날짜 중 기존 세부 일정에 포함되지 않은 날짜 추출
    List<LocalDate> datesToAdd = newDates.stream()
            .filter(date -> isDateContain(date, existingDates))  // 날짜 비교 메서드 사용
            .toList();

    // 기존 세부 일정 중 새로운 날짜 범위에 포함되지 않는 세부 일정 추출
    List<ScheduleDetails> detailsToRemove = existingDetails.stream()
            .filter(detail -> isDateContain(detail.getDate(), newDates))  // 날짜 비교 메서드 사용
            .toList();

    // 삭제할 세부 일정에 포함된 세부 계획(DetailedPlan)을 먼저 삭제
    List<DetailedPlan> detailedPlans = detailPlanRepository.findByScheduleDetails(detailsToRemove);
    detailPlanRepository.deleteAll(detailedPlans);

    // 세부 일정 삭제
    scheduleDetailsRepository.deleteAll(detailsToRemove);

    // 새로운 세부 일정들을 추가
    List<ScheduleDetails> detailsToAdd = datesToAdd.stream()
            .map(date -> ScheduleDetails.create(date, schedule))  // 새로운 세부 일정 생성
            .toList();

    // 새롭게 추가된 세부 일정들을 저장
    scheduleDetailsRepository.saveAll(detailsToAdd);
}
```
