### PR TITLE
[Feature] SSE를 활용하여 채팅 알림 구현

### DIFF
--- a/src/docs/asciidoc/api/accompany/accompany.adoc
+++ b/src/docs/asciidoc/api/accompany/accompany.adoc
@@ -31,6 +31,7 @@ include::{snippets}/accompany/findAll/response-fields.adoc[]
 ==== HTTP Request
 
 include::{snippets}/accompany/findOne/http-request.adoc[]
+include::{snippets}/accompany/findOne/path-parameters.adoc[]
 
 ==== HTTP Response
 

--- a/src/docs/asciidoc/api/notification/notification.adoc
+++ b/src/docs/asciidoc/api/notification/notification.adoc
@@ -1,0 +1,11 @@
+[[notification]]
+=== 알림 구독 API
+
+==== HTTP Request
+
+include::{snippets}/notification/sse/http-request.adoc[]
+include::{snippets}/notification/sse/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/notification/sse/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -47,3 +47,7 @@ include::api/city/city.adoc[]
 [[Auth-API]]
 == 인증/인가 API
 include::api/auth/auth.adoc[]
+
+[[Notification-API]]
+== 알림 구독 API
+include::api/notification/notification.adoc[]

--- a/src/main/java/com/wegotoo/api/notification/NotificationController.java
+++ b/src/main/java/com/wegotoo/api/notification/NotificationController.java
@@ -1,0 +1,23 @@
+package com.wegotoo.api.notification;
+
+import com.wegotoo.api.ApiResponse;
+import com.wegotoo.application.notification.NotificationService;
+import com.wegotoo.infra.resolver.auth.Auth;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RestController
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/v1/notification", produces = "text/event-stream")
+    public SseEmitter subscribeToNotification(@Auth Long userId) throws IOException {
+        return notificationService.subscribe(userId);
+    }
+
+}

--- a/src/main/java/com/wegotoo/application/chat/ChatService.java
+++ b/src/main/java/com/wegotoo/application/chat/ChatService.java
@@ -3,12 +3,14 @@ package com.wegotoo.application.chat;
 import static com.wegotoo.exception.ErrorCode.NOT_VALID_USER;
 
 import com.wegotoo.application.chat.request.ChatSendServiceRequest;
+import com.wegotoo.application.event.ChatMessageSentEvent;
 import com.wegotoo.domain.chat.Chat;
 import com.wegotoo.domain.chat.repository.ChatRepository;
 import com.wegotoo.domain.user.User;
 import com.wegotoo.domain.user.repository.UserRepository;
 import com.wegotoo.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,12 +21,15 @@ public class ChatService {
 
     private final UserRepository userRepository;
     private final ChatRepository chatRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ChatResponse sendChatMessage(Long userId, ChatSendServiceRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(NOT_VALID_USER));
 
         Chat chat = chatRepository.save(request.toDocument(user.getId()));
+
+        eventPublisher.publishEvent(ChatMessageSentEvent.to(user.getId(), request.getMessage()));
 
         return ChatResponse.of(user, chat);
     }

--- a/src/main/java/com/wegotoo/application/event/ChatMessageSentEvent.java
+++ b/src/main/java/com/wegotoo/application/event/ChatMessageSentEvent.java
@@ -1,0 +1,25 @@
+package com.wegotoo.application.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatMessageSentEvent {
+
+    private final Long receiverId;
+
+    private final String message;
+
+    @Builder
+    private ChatMessageSentEvent(Long receiverId, String message) {
+        this.receiverId = receiverId;
+        this.message = message;
+    }
+
+    public static ChatMessageSentEvent to(Long id, String message) {
+        return ChatMessageSentEvent.builder()
+                .receiverId(id)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/wegotoo/application/event/ChatMessageSentEventListener.java
+++ b/src/main/java/com/wegotoo/application/event/ChatMessageSentEventListener.java
@@ -1,0 +1,20 @@
+package com.wegotoo.application.event;
+
+import com.wegotoo.application.notification.NotificationService;
+import com.wegotoo.exception.NotificationSendException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageSentEventListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    public void handleChatMessageSentEvent(ChatMessageSentEvent event) throws NotificationSendException {
+        notificationService.notifyChatting(event.getReceiverId(), event.getMessage());
+    }
+
+}

--- a/src/main/java/com/wegotoo/application/notification/NotificationService.java
+++ b/src/main/java/com/wegotoo/application/notification/NotificationService.java
@@ -1,0 +1,84 @@
+package com.wegotoo.application.notification;
+
+import com.wegotoo.domain.notification.Notification;
+import com.wegotoo.domain.notification.repository.NotificationRepository;
+import com.wegotoo.domain.notification.repository.SseEmitterRepository;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+
+    private final SseEmitterRepository sseEmitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    private final String SUBSCRIBE_NOTIFICATION = "구독 성공";
+    private final String CHATTING_NOTIFICATION = "채팅 알림";
+
+    @Transactional
+    public SseEmitter subscribe(Long userId) throws IOException {
+        SseEmitter sseEmitter = new SseEmitter(Long.MAX_VALUE);
+
+        List<Notification> notifications = notificationRepository.findByReceiverId(userId);
+        if (hasNotifications(notifications)) {
+            sendNotifications(notifications, sseEmitter);
+            notificationRepository.deleteAllByReceiverId(userId);
+        }
+
+        setupSseEmitterHandlers(userId, sseEmitter);
+
+        sseEmitter.send(SseEmitter.event().name(SUBSCRIBE_NOTIFICATION));
+
+        sseEmitterRepository.addEmitter(userId, sseEmitter);
+
+        return sseEmitter;
+    }
+
+    @Transactional
+    public void notifyChatting(Long receiverId, String message) {
+        if (isUserSubscribed(receiverId)) {
+            SseEmitter sseEmitter = sseEmitterRepository.getEmitter(receiverId);
+            sendNotification(sseEmitter, message);
+        } else {
+            Notification notification = Notification.create(receiverId, message);
+            notificationRepository.save(notification);
+        }
+    }
+
+    private static boolean hasNotifications(List<Notification> notifications) {
+        return !notifications.isEmpty();
+    }
+
+    private void sendNotifications(List<Notification> notifications, SseEmitter sseEmitter) {
+        notifications.stream()
+                .map(Notification::getMessage)
+                .forEach(message -> sendNotification(sseEmitter, message));
+    }
+
+    private void sendNotification(SseEmitter sseEmitter, String message) {
+        try {
+            sseEmitter.send(SseEmitter.event().name(CHATTING_NOTIFICATION).data(message));
+        } catch (IOException e) {
+            log.error("알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private void setupSseEmitterHandlers(Long userId, SseEmitter sseEmitter) {
+        sseEmitter.onCompletion(() -> sseEmitterRepository.removeEmitter(userId));
+        sseEmitter.onTimeout(() -> sseEmitterRepository.removeEmitter(userId));
+        sseEmitter.onError(e -> sseEmitterRepository.removeEmitter(userId));
+    }
+
+    private boolean isUserSubscribed(Long receiverId) {
+        return sseEmitterRepository.containsEmitter(receiverId);
+    }
+
+}

--- a/src/main/java/com/wegotoo/config/SecurityConfig.java
+++ b/src/main/java/com/wegotoo/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                                 .requestMatchers("/docs/**").permitAll()
                                 .requestMatchers(GET, "/v1/accompanies/**").permitAll()
                                 .requestMatchers("/ws/**").permitAll()
+                                .requestMatchers("/v1/notification/**").permitAll()
                                 .anyRequest().authenticated())
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.authenticationEntryPoint(entryPoint))

--- a/src/main/java/com/wegotoo/domain/notification/Notification.java
+++ b/src/main/java/com/wegotoo/domain/notification/Notification.java
@@ -1,0 +1,39 @@
+package com.wegotoo.domain.notification;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long receiverId;
+
+    private String message;
+
+    @Builder
+    private Notification(Long id, Long receiverId, String message) {
+        this.id = id;
+        this.receiverId = receiverId;
+        this.message = message;
+    }
+
+    public static Notification create(Long receiverId, String message) {
+        return Notification.builder().
+                receiverId(receiverId)
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wegotoo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/wegotoo/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.wegotoo.domain.notification.repository;
+
+import com.wegotoo.domain.notification.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByReceiverId(Long userId);
+
+    void deleteAllByReceiverId(Long userId);
+}

--- a/src/main/java/com/wegotoo/domain/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/com/wegotoo/domain/notification/repository/SseEmitterRepository.java
@@ -1,0 +1,29 @@
+package com.wegotoo.domain.notification.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterRepository {
+
+    private final Map<Long, SseEmitter> sseEmitterMap = new HashMap<>();
+
+    public void addEmitter(Long userId, SseEmitter sseEmitter) {
+        sseEmitterMap.put(userId, sseEmitter);
+    }
+
+    public void removeEmitter(Long userId) {
+        sseEmitterMap.remove(userId);
+    }
+
+    public SseEmitter getEmitter(Long userId) {
+        return sseEmitterMap.get(userId);
+    }
+
+    public boolean containsEmitter(Long userId) {
+        return sseEmitterMap.containsKey(userId);
+    }
+
+}

--- a/src/main/java/com/wegotoo/exception/ErrorCode.java
+++ b/src/main/java/com/wegotoo/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     NOT_VALID_USER(401, "인증되지 않은 사용자입니다."),
     ACCOMPANY_NOT_FOUND(404, "동행 게시글을 찾을 수 없습니다."),
     MEMO_NOT_FOUND(404, "메모를 찾을 수 없습니다."),
-    INVITATION_INVALID(401, "유효하지 않은 초대입니다.");
+    INVITATION_INVALID(401, "유효하지 않은 초대입니다."),
+    FAILED_SEND_NOTIFICATION(500, "알림 전송을 실패했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/wegotoo/exception/NotificationSendException.java
+++ b/src/main/java/com/wegotoo/exception/NotificationSendException.java
@@ -1,0 +1,15 @@
+package com.wegotoo.exception;
+
+import java.io.IOException;
+import lombok.Getter;
+
+@Getter
+public class NotificationSendException extends IOException {
+
+    private final int code;
+
+    public NotificationSendException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.code = errorCode.getCode();
+    }
+}

--- a/src/test/java/com/wegotoo/api/ControllerTestSupport.java
+++ b/src/test/java/com/wegotoo/api/ControllerTestSupport.java
@@ -5,6 +5,7 @@ import com.wegotoo.application.accompany.AccompanyService;
 import com.wegotoo.application.auth.AuthService;
 import com.wegotoo.application.chatroom.ChatRoomService;
 import com.wegotoo.application.city.CityService;
+import com.wegotoo.application.notification.NotificationService;
 import com.wegotoo.application.schedule.DetailedPlanService;
 import com.wegotoo.application.schedule.MemoService;
 import com.wegotoo.application.schedule.ScheduleDetailsService;
@@ -46,5 +47,8 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected NotificationService notificationService;
 
 }

--- a/src/test/java/com/wegotoo/application/notification/NotificationServiceTest.java
+++ b/src/test/java/com/wegotoo/application/notification/NotificationServiceTest.java
@@ -1,0 +1,27 @@
+package com.wegotoo.application.notification;
+
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NotificationServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("A유저가 접속한 상태에서 메시지 알림을 전송 받을 수 있다.")
+    public void testNotifyChatting() throws IOException {
+        // given
+        Long receiverId = 1L;
+
+        notificationService.subscribe(receiverId);
+
+        // when
+        notificationService.notifyChatting(receiverId, "");
+
+    }
+}

--- a/src/test/java/com/wegotoo/docs/RestDocsSupport.java
+++ b/src/test/java/com/wegotoo/docs/RestDocsSupport.java
@@ -5,6 +5,7 @@ import com.wegotoo.application.accompany.AccompanyService;
 import com.wegotoo.application.auth.AuthService;
 import com.wegotoo.application.chatroom.ChatRoomService;
 import com.wegotoo.application.city.CityService;
+import com.wegotoo.application.notification.NotificationService;
 import com.wegotoo.application.schedule.DetailedPlanService;
 import com.wegotoo.application.schedule.MemoService;
 import com.wegotoo.application.schedule.ScheduleDetailsService;
@@ -54,6 +55,9 @@ public abstract class RestDocsSupport {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected NotificationService notificationService;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {

--- a/src/test/java/com/wegotoo/docs/notification/NotificationControllerDocs.java
+++ b/src/test/java/com/wegotoo/docs/notification/NotificationControllerDocs.java
@@ -1,0 +1,50 @@
+package com.wegotoo.docs.notification;
+
+import static com.wegotoo.support.security.MockAuthUtils.authorizationHeaderName;
+import static com.wegotoo.support.security.MockAuthUtils.mockBearerToken;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wegotoo.docs.RestDocsSupport;
+import com.wegotoo.support.security.WithAuthUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public class NotificationControllerDocs extends RestDocsSupport {
+
+    @Test
+    @WithAuthUser
+    @DisplayName("SSE 알림 구독하는 API를 호출한다.")
+    void NotificationAPI() throws Exception {
+        SseEmitter sseEmitter = new SseEmitter(Long.MAX_VALUE);
+        when(notificationService.subscribe(anyLong())).thenReturn(sseEmitter);
+
+        this.mockMvc.perform(get("/v1/notification")
+                        .header(authorizationHeaderName(), mockBearerToken())
+                        .accept("text/event-stream"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("notification/sse",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("어세스 토큰")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/wegotoo/support/ControllerWebMvcTest.java
+++ b/src/test/java/com/wegotoo/support/ControllerWebMvcTest.java
@@ -4,6 +4,7 @@ import com.wegotoo.api.accompany.AccompanyController;
 import com.wegotoo.api.auth.AuthController;
 import com.wegotoo.api.chatroom.ChatRoomController;
 import com.wegotoo.api.city.CityController;
+import com.wegotoo.api.notification.NotificationController;
 import com.wegotoo.api.schedule.DetailedPlanController;
 import com.wegotoo.api.schedule.MemoController;
 import com.wegotoo.api.schedule.ScheduleController;
@@ -32,7 +33,8 @@ import org.springframework.context.annotation.Import;
         ChatRoomController.class,
         AccompanyController.class,
         CityController.class,
-        AuthController.class
+        AuthController.class,
+        NotificationController.class
 },
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,


### PR DESCRIPTION
## 💡 연관된 이슈
close #54 

## 📝 작업 내용
SSE를 활용하여 채팅 알림 구현

## 💬 리뷰 요구 사항
* 유저 B가 SSE 구독 했을 경우 (접속 중)
![IMG_7A6F563B5913-1](https://github.com/user-attachments/assets/de3b7e03-2145-4ddf-9fa2-d6eda8640989)

* 유저 B가 SSE 구독을 안했을 경우 (오프라인)
![IMG_5B440AB730BF-1](https://github.com/user-attachments/assets/8528d27a-256f-4f52-97d5-8118fb9c2511)

이런식으로 현재 로직이 동작 중 입니다. 궁금하신 부분은 언제든 의견 남겨주세요!

### TODO
* SSE 구독 알림을 비동기처리로 적용하여 성능 항샹 시킬 수 있음
* Redis를 도입하여, 안전하게 구독알림을 관리할 수 있음 (현재는 `Compoment`로 관리 중)