### PR TITLE
[Feature] 여행 게시글 수정 API 구현

### DIFF
--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -11,3 +11,18 @@ include::{snippets}/post/create/request-headers.adoc[]
 
 include::{snippets}/post/create/http-response.adoc[]
 include::{snippets}/post/create/response-fields.adoc[]
+
+[[post-edit]]
+=== 여행 게시글 수정
+
+==== HTTP Request
+
+include::{snippets}/post/edit/http-request.adoc[]
+include::{snippets}/post/edit/path-parameters.adoc[]
+include::{snippets}/post/edit/request-fields.adoc[]
+include::{snippets}/post/edit/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/post/edit/http-response.adoc[]
+include::{snippets}/post/edit/response-fields.adoc[]

--- a/src/main/java/com/wegotoo/api/post/PostController.java
+++ b/src/main/java/com/wegotoo/api/post/PostController.java
@@ -1,6 +1,7 @@
 package com.wegotoo.api.post;
 
 import com.wegotoo.api.ApiResponse;
+import com.wegotoo.api.post.request.PostEditRequest;
 import com.wegotoo.api.post.request.PostWriteRequest;
 import com.wegotoo.application.post.PostService;
 import com.wegotoo.application.post.response.PostFindOneResponse;
@@ -8,6 +9,8 @@ import com.wegotoo.infra.resolver.auth.Auth;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +26,13 @@ public class PostController {
                                                       @RequestBody @Valid PostWriteRequest request) {
         LocalDateTime now = LocalDateTime.now().withNano(0);
         return ApiResponse.ok(postService.writePost(userId, request.toService(), now));
+    }
+
+    @PatchMapping("/v1/posts/{postId}")
+    public ApiResponse<Void> editPost(@Auth Long userId,
+                                      @PathVariable("postId") Long postId,
+                                      @RequestBody PostEditRequest request) {
+        postService.editPost(userId, postId, request.toService());
+        return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/wegotoo/api/post/request/ContentEditRequest.java
+++ b/src/main/java/com/wegotoo/api/post/request/ContentEditRequest.java
@@ -1,0 +1,40 @@
+package com.wegotoo.api.post.request;
+
+import com.wegotoo.application.post.request.ContentEditServiceRequest;
+import com.wegotoo.domain.post.ContentType;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ContentEditRequest {
+
+    private Long id;
+
+    private ContentType type;
+
+    private String text;
+
+    @Builder
+    private ContentEditRequest(Long id, ContentType type, String text) {
+        this.id = id;
+        this.type = type;
+        this.text = text;
+    }
+
+    public static ContentEditServiceRequest of(Long id, ContentType type, String text) {
+        return ContentEditServiceRequest.builder()
+                .id(id)
+                .type(type)
+                .text(text)
+                .build();
+    }
+
+    public static List<ContentEditServiceRequest> toService(List<ContentEditRequest> contents) {
+        return contents.stream()
+                .map(content -> ContentEditRequest.of(content.id, content.type, content.getText()))
+                .toList();
+    }
+}

--- a/src/main/java/com/wegotoo/api/post/request/PostEditRequest.java
+++ b/src/main/java/com/wegotoo/api/post/request/PostEditRequest.java
@@ -1,0 +1,30 @@
+package com.wegotoo.api.post.request;
+
+import com.wegotoo.application.post.request.PostEditServiceRequest;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostEditRequest {
+
+    private String title;
+
+    private List<ContentEditRequest> contents = new ArrayList<>();
+
+    @Builder
+    private PostEditRequest(String title, List<ContentEditRequest> contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public PostEditServiceRequest toService() {
+        return PostEditServiceRequest.builder()
+                .title(title)
+                .contents(ContentEditRequest.toService(contents))
+                .build();
+    }
+}

--- a/src/main/java/com/wegotoo/application/post/PostService.java
+++ b/src/main/java/com/wegotoo/application/post/PostService.java
@@ -2,6 +2,8 @@ package com.wegotoo.application.post;
 
 import static com.wegotoo.exception.ErrorCode.*;
 
+import com.wegotoo.application.post.request.ContentEditServiceRequest;
+import com.wegotoo.application.post.request.PostEditServiceRequest;
 import com.wegotoo.application.post.request.PostWriteServiceRequest;
 import com.wegotoo.application.post.response.ContentResponse;
 import com.wegotoo.application.post.response.PostFindOneResponse;
@@ -13,8 +15,9 @@ import com.wegotoo.domain.user.User;
 import com.wegotoo.domain.user.repository.UserRepository;
 import com.wegotoo.exception.BusinessException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,11 +38,43 @@ public class PostService {
         Post post = Post.create(request.getTitle(), user, date);
         Post postSave = postRepository.save(post);
 
-        List<Content> contents = request.getContents().stream().map(c -> Content.create(c.getType(), c.getText(), postSave))
+        List<Content> contents = request.getContents().stream()
+                .map(c -> Content.create(c.getType(), c.getText(), postSave))
                 .toList();
         List<Content> contentsSave = contentRepository.saveAll(contents);
 
         return PostFindOneResponse.of(postSave, user, ContentResponse.toList(contentsSave));
+    }
+
+    @Transactional
+    public void editPost(Long userId, Long postId, PostEditServiceRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(POST_NOT_FOUND));
+
+        if (!post.isOwner(user.getId())) {
+            throw new BusinessException(UNAUTHORIZED_REQUEST);
+        }
+
+        post.edit(request.getTitle());
+
+        List<Long> contentIds = request.getContents().stream()
+                .map(ContentEditServiceRequest::getId).collect(Collectors.toList());
+
+        List<Content> contents = contentRepository.findByIdIn(contentIds);
+
+        Map<Long, ContentEditServiceRequest> requestMap = request.getContents().stream()
+                .collect(Collectors.toMap(ContentEditServiceRequest::getId, r -> r));
+
+        contents.forEach(content -> {
+            ContentEditServiceRequest match = requestMap.get(content.getId());
+
+            if (match == null) {
+                throw new BusinessException(CONTENT_NOT_FOUND);
+            }
+
+            content.edit(match.getType(), match.getText());
+        });
     }
 
 }

--- a/src/main/java/com/wegotoo/application/post/PostService.java
+++ b/src/main/java/com/wegotoo/application/post/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
     public void editPost(Long userId, Long postId, PostEditServiceRequest request) {
         User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
-        Post post = postRepository.findById(postId).orElseThrow(() -> new BusinessException(POST_NOT_FOUND));
+        Post post = postRepository.findByIdWithUser(postId).orElseThrow(() -> new BusinessException(POST_NOT_FOUND));
 
         if (!post.isOwner(user.getId())) {
             throw new BusinessException(UNAUTHORIZED_REQUEST);

--- a/src/main/java/com/wegotoo/application/post/request/ContentEditServiceRequest.java
+++ b/src/main/java/com/wegotoo/application/post/request/ContentEditServiceRequest.java
@@ -1,0 +1,22 @@
+package com.wegotoo.application.post.request;
+
+import com.wegotoo.domain.post.ContentType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ContentEditServiceRequest {
+
+    private Long id;
+
+    private ContentType type;
+
+    private String text;
+
+    @Builder
+    private ContentEditServiceRequest(Long id, ContentType type, String text) {
+        this.id = id;
+        this.type = type;
+        this.text = text;
+    }
+}

--- a/src/main/java/com/wegotoo/application/post/request/PostEditServiceRequest.java
+++ b/src/main/java/com/wegotoo/application/post/request/PostEditServiceRequest.java
@@ -1,0 +1,20 @@
+package com.wegotoo.application.post.request;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostEditServiceRequest {
+
+    private String title;
+
+    private List<ContentEditServiceRequest> contents = new ArrayList<>();
+
+    @Builder
+    private PostEditServiceRequest(String title, List<ContentEditServiceRequest> contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/wegotoo/domain/post/Content.java
+++ b/src/main/java/com/wegotoo/domain/post/Content.java
@@ -50,4 +50,9 @@ public class Content {
                 .post(post)
                 .build();
     }
+
+    public void edit(ContentType type, String text) {
+        this.type = type != null ? type : this.type;
+        this.text = text != null ? text : this.text;
+    }
 }

--- a/src/main/java/com/wegotoo/domain/post/Post.java
+++ b/src/main/java/com/wegotoo/domain/post/Post.java
@@ -54,4 +54,12 @@ public class Post {
                 .registeredDateTime(registeredDateTime)
                 .build();
     }
+
+    public boolean isOwner(Long id) {
+        return user.isOwner(id);
+    }
+
+    public void edit(String title) {
+        this.title = title != null ? title : this.title;
+    }
 }

--- a/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
@@ -1,9 +1,12 @@
 package com.wegotoo.domain.post.repository;
 
 import com.wegotoo.domain.post.Content;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContentRepository extends JpaRepository<Content, Long> {
+
+    List<Content> findByIdIn(List<Long> contentIds);
 }

--- a/src/main/java/com/wegotoo/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/PostRepository.java
@@ -1,9 +1,16 @@
 package com.wegotoo.domain.post.repository;
 
 import com.wegotoo.domain.post.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query(
+            "select p from Post p join p.user where p.id = :postId"
+    )
+    Optional<Post> findByIdWithUser(Long postId);
 }

--- a/src/main/java/com/wegotoo/domain/user/User.java
+++ b/src/main/java/com/wegotoo/domain/user/User.java
@@ -70,4 +70,7 @@ public class User {
         this.refreshToken = null;
     }
 
+    public boolean isOwner(Long id) {
+        return this.id.equals(id);
+    }
 }

--- a/src/main/java/com/wegotoo/exception/ErrorCode.java
+++ b/src/main/java/com/wegotoo/exception/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     NOT_IMAGE(500, "이미지 형식이 아닙니다."),
     IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다."),
     S3_UPLOAD_FAIL(500, "이미지 업로드에 실패했습니다."),
-    CHAT_ROOM_NOT_FOUND(404, "채팅방을 찾을 수 없습니다.");
+    CHAT_ROOM_NOT_FOUND(404, "채팅방을 찾을 수 없습니다."),
+    POST_NOT_FOUND(404, "게시글을 찾을 수 없습니다."),
+    CONTENT_NOT_FOUND(404, "컨텐츠를 찾을 수 없습니다.");
 
     private final int code;
     private final String message;

--- a/src/test/java/com/wegotoo/api/post/PostControllerTest.java
+++ b/src/test/java/com/wegotoo/api/post/PostControllerTest.java
@@ -1,13 +1,16 @@
 package com.wegotoo.api.post;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wegotoo.api.ControllerTestSupport;
+import com.wegotoo.api.post.request.ContentEditRequest;
 import com.wegotoo.api.post.request.ContentWriteRequest;
+import com.wegotoo.api.post.request.PostEditRequest;
 import com.wegotoo.api.post.request.PostWriteRequest;
 import com.wegotoo.domain.post.ContentType;
 import com.wegotoo.support.security.WithAuthUser;
@@ -97,6 +100,33 @@ class PostControllerTest extends ControllerTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("TEXT는 필수입니다."));
+    }
+
+    @Test
+    @WithAuthUser
+    @DisplayName("유저가 게시글을 수정하는 API를 호출한다.")
+    void editPost() throws Exception {
+        // given
+        ContentEditRequest content = ContentEditRequest.builder()
+                .id(0L)
+                .type(ContentType.T)
+                .text("첫 문단 수정")
+                .build();
+
+        PostEditRequest request = PostEditRequest.builder()
+                .title("제목 수정")
+                .contents(List.of(content))
+                .build();
+        // when // then
+        mockMvc.perform(patch("/v1/posts/{postId}", 1L)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
     }
 
     private static PostWriteRequest getPostWriteRequest(List<ContentWriteRequest> contents) {

--- a/src/test/java/com/wegotoo/application/post/PostServiceTest.java
+++ b/src/test/java/com/wegotoo/application/post/PostServiceTest.java
@@ -1,12 +1,16 @@
 package com.wegotoo.application.post;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wegotoo.application.ServiceTestSupport;
+import com.wegotoo.application.post.request.ContentEditServiceRequest;
 import com.wegotoo.application.post.request.ContentWriteServiceRequest;
+import com.wegotoo.application.post.request.PostEditServiceRequest;
 import com.wegotoo.application.post.request.PostWriteServiceRequest;
 import com.wegotoo.application.post.response.PostFindOneResponse;
+import com.wegotoo.domain.post.Content;
 import com.wegotoo.domain.post.ContentType;
+import com.wegotoo.domain.post.Post;
 import com.wegotoo.domain.post.repository.ContentRepository;
 import com.wegotoo.domain.post.repository.PostRepository;
 import com.wegotoo.domain.user.User;
@@ -44,10 +48,7 @@ class PostServiceTest extends ServiceTestSupport {
     @DisplayName("유저가 게시글을 작성할 수 있다.")
     void writePost() throws Exception {
         // given
-        User user = User.builder()
-                .name("user")
-                .email("user@email.com")
-                .build();
+        User user = getUser();
         userRepository.save(user);
 
         List<ContentWriteServiceRequest> contents = IntStream.range(0, 4)
@@ -69,5 +70,76 @@ class PostServiceTest extends ServiceTestSupport {
         assertThat(response.getContents().get(0))
                 .extracting("id", "type", "text")
                 .contains(1L, ContentType.T, "내용 0");
+    }
+
+    @Test
+    @DisplayName("유저가 게시글을 수정할 수 있다.")
+    void editPost() throws Exception {
+        // given
+        User user = getUser();
+        userRepository.save(user);
+
+        Post post = getPost(user);
+        postRepository.save(post);
+
+        List<Content> contents = getContentList(post);
+        contentRepository.saveAll(contents);
+
+        ContentEditServiceRequest content1 = getContentEdit(contents.get(0).getId(), "첫 문단 수정");
+        ContentEditServiceRequest content2 = getContentEdit(contents.get(1).getId(), "두 번째 문단 수정");
+
+        List<ContentEditServiceRequest> contentRequests = List.of(content1, content2);
+
+        PostEditServiceRequest request = PostEditServiceRequest.builder()
+                .title("제목 수정")
+                .contents(contentRequests)
+                .build();
+
+        // when
+        postService.editPost(user.getId(), post.getId(), request);
+
+        // then
+        List<Post> response = postRepository.findAll();
+        List<Content> contentList = contentRepository.findAll();
+        assertThat(response.get(0))
+                .extracting("id", "title")
+                .contains(response.get(0).getId(), "제목 수정");
+
+        assertThat(contentList.get(0))
+                .extracting("id", "text")
+                .contains(contentList.get(0).getId(), "첫 문단 수정");
+
+    }
+
+    private static List<Content> getContentList(Post post) {
+        return IntStream.range(0, 2)
+                .mapToObj(i -> Content.builder()
+                        .type(ContentType.T)
+                        .text("내용 " + i)
+                        .post(post)
+                        .build()).toList();
+    }
+
+    private static Post getPost(User user) {
+        return Post.builder()
+                .title("제목")
+                .view(0)
+                .user(user)
+                .build();
+    }
+
+    private static User getUser() {
+        return User.builder()
+                .name("user")
+                .email("user@email.com")
+                .build();
+    }
+
+    private static ContentEditServiceRequest getContentEdit(Long id, String text) {
+        return ContentEditServiceRequest.builder()
+                .id(id)
+                .type(ContentType.T)
+                .text(text)
+                .build();
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #69 

## 📝 작업 내용
-  여행 게시글 수정 API 구현
-  여행 게시글 수정 API 테스트 코드 작성
-  여행 게시글 수정 API REST Docs 작성

## 💬 리뷰 요구 사항
현재 수정 로직은

```json
{
  "title": "수정된 제목",
  "contents": [
    {
      "id": 1,
      "type": "T",
      "text": "수정된 첫 번째 문단"
    },
    {
      "id": 2,
      "type": "T",
      "text": "수정된 두 번째 문단"
    }
  ]
}
```

이렇게 데이터를 받고 원래 있던 데이터를 수정하는 로직으로 구현하였습니다. 질문이나 개선할 부분이 있다면 언제든 리뷰 남겨주세요!