### PR TITLE
[Feature] 여행 게시글 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/api/accompany/accompany.adoc
+++ b/src/docs/asciidoc/api/accompany/accompany.adoc
@@ -13,7 +13,7 @@ include::{snippets}/accompany/create/http-response.adoc[]
 include::{snippets}/accompany/create/response-fields.adoc[]
 
 [[accompany-findAll]]
-=== 동행 모집 글 조회
+=== 동행 모집 글 무한 스크롤 조회
 
 ==== HTTP Request
 

--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -12,6 +12,19 @@ include::{snippets}/post/create/request-headers.adoc[]
 include::{snippets}/post/create/http-response.adoc[]
 include::{snippets}/post/create/response-fields.adoc[]
 
+[[post-findAll]]
+=== 동행 모집 글 조회
+
+==== HTTP Request
+
+include::{snippets}/post/findAll/http-request.adoc[]
+include::{snippets}/post/findAll/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/post/findAll/http-response.adoc[]
+include::{snippets}/post/findAll/response-fields.adoc[]
+
 [[post-edit]]
 === 여행 게시글 수정
 

--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -13,7 +13,7 @@ include::{snippets}/post/create/http-response.adoc[]
 include::{snippets}/post/create/response-fields.adoc[]
 
 [[post-findAll]]
-=== 동행 모집 글 조회
+=== 여행 게시글 무한 스크롤 조회
 
 ==== HTTP Request
 
@@ -24,6 +24,19 @@ include::{snippets}/post/findAll/query-parameters.adoc[]
 
 include::{snippets}/post/findAll/http-response.adoc[]
 include::{snippets}/post/findAll/response-fields.adoc[]
+
+[[post-findOne]]
+=== 여행 게시글 단 건 조회
+
+==== HTTP Request
+
+include::{snippets}/post/findOne/http-request.adoc[]
+include::{snippets}/post/findOne/path-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/post/findOne/http-response.adoc[]
+include::{snippets}/post/findOne/response-fields.adoc[]
 
 [[post-edit]]
 === 여행 게시글 수정

--- a/src/main/java/com/wegotoo/api/post/PostController.java
+++ b/src/main/java/com/wegotoo/api/post/PostController.java
@@ -41,6 +41,11 @@ public class PostController {
         return ApiResponse.ok(postService.findAllPost(OffsetLimit.of(page, size)));
     }
 
+    @GetMapping("/v1/posts/{postId}")
+    public ApiResponse<PostFindOneResponse> findOnePost(@PathVariable("postId") Long postId) {
+        return ApiResponse.ok(postService.findOnePost(postId));
+    }
+
     @PatchMapping("/v1/posts/{postId}")
     public ApiResponse<Void> editPost(@Auth Long userId,
                                       @PathVariable("postId") Long postId,

--- a/src/main/java/com/wegotoo/api/post/PostController.java
+++ b/src/main/java/com/wegotoo/api/post/PostController.java
@@ -3,16 +3,21 @@ package com.wegotoo.api.post;
 import com.wegotoo.api.ApiResponse;
 import com.wegotoo.api.post.request.PostEditRequest;
 import com.wegotoo.api.post.request.PostWriteRequest;
+import com.wegotoo.application.OffsetLimit;
+import com.wegotoo.application.SliceResponse;
 import com.wegotoo.application.post.PostService;
+import com.wegotoo.application.post.response.PostFindAllResponse;
 import com.wegotoo.application.post.response.PostFindOneResponse;
 import com.wegotoo.infra.resolver.auth.Auth;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -26,6 +31,14 @@ public class PostController {
                                                       @RequestBody @Valid PostWriteRequest request) {
         LocalDateTime now = LocalDateTime.now().withNano(0);
         return ApiResponse.ok(postService.writePost(userId, request.toService(), now));
+    }
+
+    @GetMapping("/v1/posts")
+    public ApiResponse<SliceResponse<PostFindAllResponse>> findAllPosts(
+            @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
+            @RequestParam(value = "size", required = false, defaultValue = "4") Integer size
+    ) {
+        return ApiResponse.ok(postService.findAllPost(OffsetLimit.of(page, size)));
     }
 
     @PatchMapping("/v1/posts/{postId}")

--- a/src/main/java/com/wegotoo/application/post/PostService.java
+++ b/src/main/java/com/wegotoo/application/post/PostService.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -68,6 +67,13 @@ public class PostService {
 
         return SliceResponse.of(PostFindAllResponse.toList(posts, firstContentText, firstContentImage),
                 offsetLimit.getOffset(), offsetLimit.getLimit());
+    }
+
+    public PostFindOneResponse findOnePost(Long postId) {
+        Post post = postRepository.findByIdWithUser(postId).orElseThrow(() -> new BusinessException(POST_NOT_FOUND));
+
+        List<Content> contents = contentRepository.findAllByPostIdOrderByIdAsc(post.getId());
+        return PostFindOneResponse.of(post, post.getUser(), ContentResponse.toList(contents));
     }
 
     @Transactional

--- a/src/main/java/com/wegotoo/application/post/PostService.java
+++ b/src/main/java/com/wegotoo/application/post/PostService.java
@@ -2,21 +2,30 @@ package com.wegotoo.application.post;
 
 import static com.wegotoo.exception.ErrorCode.*;
 
+import com.wegotoo.application.OffsetLimit;
+import com.wegotoo.application.SliceResponse;
 import com.wegotoo.application.post.request.ContentEditServiceRequest;
 import com.wegotoo.application.post.request.PostEditServiceRequest;
 import com.wegotoo.application.post.request.PostWriteServiceRequest;
 import com.wegotoo.application.post.response.ContentResponse;
+import com.wegotoo.application.post.response.PostFindAllResponse;
 import com.wegotoo.application.post.response.PostFindOneResponse;
 import com.wegotoo.domain.post.Content;
 import com.wegotoo.domain.post.Post;
 import com.wegotoo.domain.post.repository.ContentRepository;
 import com.wegotoo.domain.post.repository.PostRepository;
+import com.wegotoo.domain.post.repository.response.ContentImageQueryEntity;
+import com.wegotoo.domain.post.repository.response.ContentTextQueryEntity;
+import com.wegotoo.domain.post.repository.response.PostQueryEntity;
 import com.wegotoo.domain.user.User;
 import com.wegotoo.domain.user.repository.UserRepository;
 import com.wegotoo.exception.BusinessException;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,6 +53,21 @@ public class PostService {
         List<Content> contentsSave = contentRepository.saveAll(contents);
 
         return PostFindOneResponse.of(postSave, user, ContentResponse.toList(contentsSave));
+    }
+
+    public SliceResponse<PostFindAllResponse> findAllPost(OffsetLimit offsetLimit) {
+        List<PostQueryEntity> posts = postRepository.findAllPost(offsetLimit.getOffset(), offsetLimit.getLimit());
+
+        List<Long> postIds = posts.stream().map(PostQueryEntity::getId).toList();
+
+        List<ContentTextQueryEntity> allContentTexts = contentRepository.findAllPostWithContentText(postIds);
+        List<ContentImageQueryEntity> allContentImages = contentRepository.findAllPostWithContentImage(postIds);
+
+        List<ContentTextQueryEntity> firstContentText = getFirstContentText(allContentTexts);
+        List<ContentImageQueryEntity> firstContentImage = getFirstContentImage(allContentImages);
+
+        return SliceResponse.of(PostFindAllResponse.toList(posts, firstContentText, firstContentImage),
+                offsetLimit.getOffset(), offsetLimit.getLimit());
     }
 
     @Transactional
@@ -75,6 +99,28 @@ public class PostService {
 
             content.edit(match.getType(), match.getText());
         });
+    }
+
+    private List<ContentImageQueryEntity> getFirstContentImage(List<ContentImageQueryEntity> allContentImages) {
+        return allContentImages.stream()
+                .collect(Collectors.groupingBy(ContentImageQueryEntity::getPostId))
+                .values().stream()
+                .map(list -> list.stream()
+                        .min(Comparator.comparing(ContentImageQueryEntity::getContentId))
+                        .orElse(null))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private List<ContentTextQueryEntity> getFirstContentText(List<ContentTextQueryEntity> allContentTexts) {
+        return allContentTexts.stream()
+                .collect(Collectors.groupingBy(ContentTextQueryEntity::getPostId))
+                .values().stream()
+                .map(list -> list.stream()
+                        .min(Comparator.comparing(ContentTextQueryEntity::getContentId))
+                        .orElse(null))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
 }

--- a/src/main/java/com/wegotoo/application/post/response/PostFindAllResponse.java
+++ b/src/main/java/com/wegotoo/application/post/response/PostFindAllResponse.java
@@ -1,0 +1,90 @@
+package com.wegotoo.application.post.response;
+
+import com.wegotoo.domain.post.repository.response.ContentImageQueryEntity;
+import com.wegotoo.domain.post.repository.response.ContentTextQueryEntity;
+import com.wegotoo.domain.post.repository.response.PostQueryEntity;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostFindAllResponse {
+
+    private Long postId;
+
+    private String title;
+
+    private String content;
+
+    private String thumbnail;
+
+    private String userName;
+
+    private String userProfileImage;
+
+    private LocalDateTime registeredDateTime;
+
+    @Builder
+    private PostFindAllResponse(Long postId, String title, String content, String thumbnail, String userName,
+                                String userProfileImage, LocalDateTime registeredDateTime) {
+        this.postId = postId;
+        this.title = title;
+        this.content = content;
+        this.thumbnail = thumbnail;
+        this.userName = userName;
+        this.userProfileImage = userProfileImage;
+        this.registeredDateTime = registeredDateTime;
+    }
+
+    public static PostFindAllResponse of(PostQueryEntity post, String content, String thumbnail) {
+        return PostFindAllResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(content)
+                .thumbnail(thumbnail)
+                .userName(post.getUserName())
+                .userProfileImage(post.getUserProfileImage())
+                .registeredDateTime(post.getRegistrationDate())
+                .build();
+    }
+
+    public static List<PostFindAllResponse> toList(List<PostQueryEntity> posts,
+                                                   List<ContentTextQueryEntity> texts,
+                                                   List<ContentImageQueryEntity> images) {
+        Map<Long, String> textMap = toTextMap(texts);
+        Map<Long, String> imageMap = toImageMap(images);
+        return posts.stream()
+                .map(post -> PostFindAllResponse.of(post, textMap.get(post.getId()), imageMap.get(post.getId())))
+                .toList();
+    }
+
+    private static Map<Long, String> toTextMap(List<ContentTextQueryEntity> contents) {
+        if (contents == null) {
+            return Collections.emptyMap();
+        }
+        return contents.stream()
+                .collect(Collectors.toMap(
+                        ContentTextQueryEntity::getPostId,
+                        ContentTextQueryEntity::getText,
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    private static Map<Long, String> toImageMap(List<ContentImageQueryEntity> contents) {
+        if (contents == null) {
+            return Collections.emptyMap();
+        }
+        return contents.stream()
+                .collect(Collectors.toMap(
+                        ContentImageQueryEntity::getPostId,
+                        ContentImageQueryEntity::getImage,
+                        (existing, replacement) -> existing
+                ));
+    }
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface ContentRepository extends JpaRepository<Content, Long>, ContentRepositoryCustom {
 
     List<Content> findByIdIn(List<Long> contentIds);
+
+    List<Content> findAllByPostIdOrderByIdAsc(Long id);
 }

--- a/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/ContentRepository.java
@@ -1,12 +1,13 @@
 package com.wegotoo.domain.post.repository;
 
 import com.wegotoo.domain.post.Content;
+import com.wegotoo.domain.post.repository.querydsl.ContentRepositoryCustom;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ContentRepository extends JpaRepository<Content, Long> {
+public interface ContentRepository extends JpaRepository<Content, Long>, ContentRepositoryCustom {
 
     List<Content> findByIdIn(List<Long> contentIds);
 }

--- a/src/main/java/com/wegotoo/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/PostRepository.java
@@ -1,13 +1,14 @@
 package com.wegotoo.domain.post.repository;
 
 import com.wegotoo.domain.post.Post;
+import com.wegotoo.domain.post.repository.querydsl.PostRepositoryCustom;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     @Query(
             "select p from Post p join p.user where p.id = :postId"

--- a/src/main/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryCustom.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import com.wegotoo.domain.post.repository.response.ContentImageQueryEntity;
+import com.wegotoo.domain.post.repository.response.ContentTextQueryEntity;
+import java.util.List;
+
+public interface ContentRepositoryCustom {
+    List<ContentTextQueryEntity> findAllPostWithContentText(List<Long> postIds);
+
+    List<ContentImageQueryEntity> findAllPostWithContentImage(List<Long> postIds);
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryImpl.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import static com.wegotoo.domain.post.QContent.content;
+import static com.wegotoo.domain.post.QPost.post;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wegotoo.domain.post.ContentType;
+import com.wegotoo.domain.post.repository.response.ContentImageQueryEntity;
+import com.wegotoo.domain.post.repository.response.ContentTextQueryEntity;
+import com.wegotoo.domain.post.repository.response.QContentImageQueryEntity;
+import com.wegotoo.domain.post.repository.response.QContentTextQueryEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentRepositoryImpl implements ContentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ContentTextQueryEntity> findAllPostWithContentText(List<Long> postIds) {
+        return queryFactory.select(new QContentTextQueryEntity(
+                        post.id,
+                        content.id,
+                        content.text
+                ))
+                .from(content)
+                .join(content.post, post)
+                .where(content.post.id.in(postIds).and(content.type.eq(ContentType.T)))
+                .groupBy(post.id, content.id)
+                .fetch();
+    }
+
+    @Override
+    public List<ContentImageQueryEntity> findAllPostWithContentImage(List<Long> postIds) {
+        return queryFactory.select(new QContentImageQueryEntity(
+                        post.id,
+                        content.id,
+                        content.text
+                ))
+                .from(content)
+                .join(content.post, post)
+                .where(content.post.id.in(postIds).and(content.type.eq(ContentType.IMAGE)))
+                .groupBy(post.id, content.id)
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import com.wegotoo.domain.post.repository.response.PostQueryEntity;
+import java.util.List;
+
+public interface PostRepositoryCustom {
+    List<PostQueryEntity> findAllPost(Integer offset, Integer size);
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import static com.wegotoo.domain.post.QPost.post;
+import static com.wegotoo.domain.user.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wegotoo.domain.post.repository.response.PostQueryEntity;
+import com.wegotoo.domain.post.repository.response.QPostQueryEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PostQueryEntity> findAllPost(Integer offset, Integer size) {
+        return queryFactory.select(new QPostQueryEntity(
+                post.id,
+                post.title,
+                user.name,
+                user.profileImage,
+                post.registeredDateTime
+        ))
+                .from(post)
+                .join(post.user, user)
+                .offset(offset)
+                .limit(size + 1)
+                .groupBy(post.id)
+                .orderBy(post.registeredDateTime.desc())
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/response/ContentImageQueryEntity.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/response/ContentImageQueryEntity.java
@@ -1,0 +1,25 @@
+package com.wegotoo.domain.post.repository.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ContentImageQueryEntity {
+
+    private Long postId;
+
+    private Long contentId;
+
+    private String image;
+
+    @Builder
+    @QueryProjection
+    public ContentImageQueryEntity(Long postId, Long contentId, String image) {
+        this.postId = postId;
+        this.contentId = contentId;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/response/ContentTextQueryEntity.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/response/ContentTextQueryEntity.java
@@ -1,0 +1,25 @@
+package com.wegotoo.domain.post.repository.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ContentTextQueryEntity {
+
+    private Long postId;
+
+    private Long contentId;
+
+    private String text;
+
+    @Builder
+    @QueryProjection
+    public ContentTextQueryEntity(Long postId, Long contentId, String text) {
+        this.postId = postId;
+        this.contentId = contentId;
+        this.text = text;
+    }
+}

--- a/src/main/java/com/wegotoo/domain/post/repository/response/PostQueryEntity.java
+++ b/src/main/java/com/wegotoo/domain/post/repository/response/PostQueryEntity.java
@@ -1,0 +1,34 @@
+package com.wegotoo.domain.post.repository.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostQueryEntity {
+
+    private Long id;
+
+    private String title;
+
+    private String userName;
+
+    private String userProfileImage;
+
+    private LocalDateTime registrationDate;
+
+    @Builder
+    @QueryProjection
+    public PostQueryEntity(Long id, String title, String userName, String userProfileImage,
+                            LocalDateTime registrationDate) {
+        this.id = id;
+        this.title = title;
+        this.userName = userName;
+        this.userProfileImage = userProfileImage;
+        this.registrationDate = registrationDate;
+    }
+
+}

--- a/src/test/java/com/wegotoo/application/post/PostServiceTest.java
+++ b/src/test/java/com/wegotoo/application/post/PostServiceTest.java
@@ -165,6 +165,35 @@ class PostServiceTest extends ServiceTestSupport {
                 .contains(post.getId(), "제목", "글1", "이미지1", user.getName(), "이미지");
     }
 
+    @Test
+    @DisplayName("게시글을 단건 조회 하면 컨텐츠 블록도 같이 출력된다.")
+    void findOnePost() throws Exception {
+        // given
+        User user = User.builder()
+                .name("user")
+                .email("user@email.com")
+                .build();
+        userRepository.save(user);
+
+        Post post = Post.builder()
+                .title("제목 ")
+                .view(0)
+                .user(user)
+                .build();
+        postRepository.save(post);
+
+        Content content1 = getContent(post, ContentType.T, "글1");
+        Content content2 = getContent(post, ContentType.IMAGE, "이미지1");
+        Content content3 = getContent(post, ContentType.T, "글2");
+        Content content4 = getContent(post, ContentType.IMAGE, "이미지2");
+
+        contentRepository.saveAll(List.of(content1, content2, content3, content4));
+        // when
+        PostFindOneResponse response = postService.findOnePost(post.getId());
+        // then
+        assertThat(response.getContents().size()).isEqualTo(4);
+    }
+
     private static Content getContent(Post post, ContentType type, String text) {
         return Content.builder()
                 .type(type)

--- a/src/test/java/com/wegotoo/docs/post/PostControllerDocs.java
+++ b/src/test/java/com/wegotoo/docs/post/PostControllerDocs.java
@@ -9,12 +9,14 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NULL;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
@@ -24,6 +26,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -31,7 +34,11 @@ import com.wegotoo.api.post.request.ContentEditRequest;
 import com.wegotoo.api.post.request.ContentWriteRequest;
 import com.wegotoo.api.post.request.PostEditRequest;
 import com.wegotoo.api.post.request.PostWriteRequest;
+import com.wegotoo.application.OffsetLimit;
+import com.wegotoo.application.SliceResponse;
+import com.wegotoo.application.accompany.response.AccompanyFindAllResponse;
 import com.wegotoo.application.post.response.ContentResponse;
+import com.wegotoo.application.post.response.PostFindAllResponse;
 import com.wegotoo.application.post.response.PostFindOneResponse;
 import com.wegotoo.docs.RestDocsSupport;
 import com.wegotoo.domain.post.ContentType;
@@ -150,6 +157,91 @@ public class PostControllerDocs extends RestDocsSupport {
                                         .description("타입"),
                                 fieldWithPath("data.contents[].text").type(STRING)
                                         .description("내용")
+                        )
+                ));
+    }
+
+    @Test
+    @WithAuthUser
+    @DisplayName("여행 게시글을 조회하는 API")
+    void findAllPosts() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now().withNano(0);
+
+        PostFindAllResponse findAllResponse = PostFindAllResponse.builder()
+                .postId(1L)
+                .title("제목")
+                .content("첫 문단")
+                .thumbnail("첫 이미지")
+                .userName("작성자 이름")
+                .userProfileImage("작성자 프로필 이미지")
+                .registeredDateTime(now)
+                .build();
+
+        SliceResponse<PostFindAllResponse> response = SliceResponse.<PostFindAllResponse>builder()
+                .content(List.of(findAllResponse))
+                .hasContent(true)
+                .number(1)
+                .size(4)
+                .first(true)
+                .last(false)
+                .build();
+        // when
+        given(postService.findAllPost(any(OffsetLimit.class)))
+                .willReturn(response);
+
+        // then
+        mockMvc.perform(get("/v1/posts")
+                        .param("page", "1")
+                        .param("size", "4")
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("post/findAll",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지")
+                                        .optional(),
+                                parameterWithName("size").description("페이지 사이즈")
+                                        .optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메시지"),
+                                fieldWithPath("data").type(OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.hasContent").type(BOOLEAN)
+                                        .description("데이터 존재 여부"),
+                                fieldWithPath("data.isFirst").type(BOOLEAN)
+                                        .description("첫 번째 페이지 여부"),
+                                fieldWithPath("data.isLast").type(BOOLEAN)
+                                        .description("마지막 페이지 여부"),
+                                fieldWithPath("data.number").type(NUMBER)
+                                        .description("현재 페이지 번호"),
+                                fieldWithPath("data.size").type(NUMBER)
+                                        .description("게시글 반환 사이즈"),
+                                fieldWithPath("data.content[]").type(ARRAY)
+                                        .description("여행 일정 데이터"),
+                                fieldWithPath("data.content[].postId").type(NUMBER)
+                                        .description("Post ID"),
+                                fieldWithPath("data.content[].title").type(STRING)
+                                        .description("게시글 제목"),
+                                fieldWithPath("data.content[].content").type(STRING)
+                                        .description("게시글 첫 문단"),
+                                fieldWithPath("data.content[].thumbnail").type(STRING)
+                                        .description("썸네일"),
+                                fieldWithPath("data.content[].userName").type(STRING)
+                                        .description("작성자 이름"),
+                                fieldWithPath("data.content[].userProfileImage").type(STRING)
+                                        .description("유저 프로필 이미지"),
+                                fieldWithPath("data.content[].registeredDateTime").type(STRING)
+                                        .description("작성 일자")
                         )
                 ));
     }

--- a/src/test/java/com/wegotoo/docs/post/PostControllerDocs.java
+++ b/src/test/java/com/wegotoo/docs/post/PostControllerDocs.java
@@ -1,5 +1,6 @@
 package com.wegotoo.docs.post;
 
+import static com.wegotoo.domain.accompany.Gender.NO_MATTER;
 import static com.wegotoo.support.security.MockAuthUtils.authorizationHeaderName;
 import static com.wegotoo.support.security.MockAuthUtils.mockBearerToken;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,6 +38,7 @@ import com.wegotoo.api.post.request.PostWriteRequest;
 import com.wegotoo.application.OffsetLimit;
 import com.wegotoo.application.SliceResponse;
 import com.wegotoo.application.accompany.response.AccompanyFindAllResponse;
+import com.wegotoo.application.accompany.response.AccompanyFindOneResponse;
 import com.wegotoo.application.post.response.ContentResponse;
 import com.wegotoo.application.post.response.PostFindAllResponse;
 import com.wegotoo.application.post.response.PostFindOneResponse;
@@ -242,6 +244,85 @@ public class PostControllerDocs extends RestDocsSupport {
                                         .description("유저 프로필 이미지"),
                                 fieldWithPath("data.content[].registeredDateTime").type(STRING)
                                         .description("작성 일자")
+                        )
+                ));
+    }
+
+    @Test
+    @WithAuthUser
+    @DisplayName("여행 게시글을 단 건 조회하는 API")
+    void findOneAccompany() throws Exception {
+        // given
+        ContentResponse text = ContentResponse.builder()
+                .id(1L)
+                .type(ContentType.T)
+                .text("내용")
+                .build();
+
+        ContentResponse image = ContentResponse.builder()
+                .id(2L)
+                .type(ContentType.IMAGE)
+                .text("이미지 URL")
+                .build();
+        List<ContentResponse> content = new ArrayList<>();
+        content.add(text);
+        content.add(image);
+
+        PostFindOneResponse response = PostFindOneResponse.builder()
+                .id(1L)
+                .title("제목")
+                .userName("작성자 이름")
+                .userProfileImage("작성자 프로필 이미지 URL")
+                .views(0)
+                .contents(content)
+                .registeredDateTime(LocalDateTime.now().withNano(0))
+                .build();
+
+        given(postService.findOnePost(anyLong()))
+                .willReturn(response);
+
+        // when // then
+        mockMvc.perform(get("/v1/posts/{postId}", 1L)
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("post/findOne",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId")
+                                        .description("Post ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메시지"),
+                                fieldWithPath("data").type(OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.id").type(NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data.title").type(STRING)
+                                        .description("제목"),
+                                fieldWithPath("data.userName").type(STRING)
+                                        .description("작성자 이름"),
+                                fieldWithPath("data.userProfileImage").type(STRING)
+                                        .description("유저 프로필 이미지"),
+                                fieldWithPath("data.views").type(NUMBER)
+                                        .description("조회수 (10.2 아직 조회수 기능은 구현 X)"),
+                                fieldWithPath("data.registeredDateTime").type(STRING)
+                                        .description("작성 일자"),
+                                fieldWithPath("data.contents").type(ARRAY)
+                                        .description("문단 별 Content"),
+                                fieldWithPath("data.contents[].id").type(NUMBER)
+                                        .description("Content 순서"),
+                                fieldWithPath("data.contents[].type").type(STRING)
+                                        .description("타입"),
+                                fieldWithPath("data.contents[].text").type(STRING)
+                                        .description("내용")
                         )
                 ));
     }

--- a/src/test/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryImplTest.java
+++ b/src/test/java/com/wegotoo/domain/post/repository/querydsl/ContentRepositoryImplTest.java
@@ -1,0 +1,80 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wegotoo.config.QueryDslConfig;
+import com.wegotoo.domain.post.Content;
+import com.wegotoo.domain.post.ContentType;
+import com.wegotoo.domain.post.Post;
+import com.wegotoo.domain.post.repository.ContentRepository;
+import com.wegotoo.domain.post.repository.PostRepository;
+import com.wegotoo.domain.post.repository.response.ContentTextQueryEntity;
+import com.wegotoo.domain.user.User;
+import com.wegotoo.domain.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class ContentRepositoryImplTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    ContentRepository contentRepository;
+
+    @AfterEach
+    void tearDown() {
+        contentRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("게시글 페이징 조회 테스트")
+    void findAllPost() throws Exception {
+        // given
+        User user = User.builder()
+                .name("user")
+                .email("user@email.com")
+                .build();
+        userRepository.save(user);
+
+        Post post = Post.builder()
+                .title("제목 ")
+                .view(0)
+                .user(user)
+                .build();
+        postRepository.save(post);
+
+        Content content1 = getContent(post, ContentType.T, "글1");
+        Content content2 = getContent(post, ContentType.IMAGE, "이미지1");
+        Content content3 = getContent(post, ContentType.T, "글2");
+        Content content4 = getContent(post, ContentType.IMAGE, "이미지2");
+
+        contentRepository.saveAll(List.of(content1, content2, content3, content4));
+
+        // when
+        List<ContentTextQueryEntity> response = contentRepository.findAllPostWithContentText(List.of(1L));
+
+        // then
+        assertThat(response.size()).isEqualTo(2);
+    }
+
+    private static Content getContent(Post post, ContentType type, String text) {
+        return Content.builder()
+                .type(type)
+                .post(post)
+                .text(text)
+                .build();
+    }
+}

--- a/src/test/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryImplTest.java
+++ b/src/test/java/com/wegotoo/domain/post/repository/querydsl/PostRepositoryImplTest.java
@@ -1,0 +1,61 @@
+package com.wegotoo.domain.post.repository.querydsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wegotoo.config.QueryDslConfig;
+import com.wegotoo.domain.post.Post;
+import com.wegotoo.domain.post.repository.PostRepository;
+import com.wegotoo.domain.post.repository.response.PostQueryEntity;
+import com.wegotoo.domain.user.User;
+import com.wegotoo.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class PostRepositoryImplTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @AfterEach
+    void tearDown() {
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("게시글 페이징 조회 테스트")
+    void findAllPost() throws Exception {
+        // given
+        User user = User.builder()
+                .name("user")
+                .email("user@email.com")
+                .build();
+        userRepository.save(user);
+
+        List<Post> posts = IntStream.range(0, 5)
+                .mapToObj(i -> Post.builder()
+                        .title("제목 " + i)
+                        .view(0)
+                        .user(user)
+                        .registeredDateTime(LocalDateTime.now())
+                        .build()).toList();
+        postRepository.saveAll(posts);
+        // when
+        List<PostQueryEntity> response = postRepository.findAllPost(0, 4);
+
+        // then
+        assertThat(response.size()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #72 

## 📝 작업 내용
- 여행 게시글 무한 스크롤 API 구현
- 여행 게시글 무한 스크롤 API 테스트 코드 작성
- 여행 게시글 무한 스크롤 API REST Docs 작성
- 여행 게시글 단 건 조회 API 구현
- 여행 게시글 단 건 조회 API 테스트 코드 작성
- 여행 게시글 단 건 조회 API REST Docs 작성

## 💬 리뷰 요구 사항
현재 여행 게시글 조회 시 `post` 조회 후 `content_text`와 `content_image`를 각각 따로 조회 후 서비스로직에서 자바 후처리로 합쳐줬습니다. 해당 로직을 유지해야 할지 아니면 서브쿼리를 사용해야할지 고민이 되는데, 의견 남겨주시면 감사하겠습니다.

* 서브쿼리 VS 자바 후처리
  ||서브쿼리|자바 후처리|
  |------|---|---|
  |장점|간결한  애플리케이션 로직, 대량의 데이터 일 경우 자바 후처리보다는 빠름|데이터베이스 부담 감소, 애플리케이션 내 유연성|
  |단점|데이터베이스 부하, 복잡한 쿼리|메모리 부족(하지만 현대에선 미미할 것으로 생각이 듬), 애플리케이션 부하|