### PR TITLE
[Feature] RabbitMQ 메세지 전송 유실 방지 기능 추가

### DIFF
--- a/.github/workflows/wegotoo_dev.yml
+++ b/.github/workflows/wegotoo_dev.yml
@@ -56,12 +56,20 @@ jobs:
           DEV_SECRET_DIR_FILE_NAME: application-oauth.yml
         run: echo $DEV_SECRET | base64 --decode >> $DEV_SECRET_DIR/$DEV_SECRET_DIR_FILE_NAME
 
-        # application-s3.yml
+      # application-s3.yml
       - name: Copy s3 Secret
         env:
           DEV_SECRET: ${{ secrets.APPLICATION_S3_YML }}
           DEV_SECRET_DIR: src/main/resources
           DEV_SECRET_DIR_FILE_NAME: application-s3.yml
+        run: echo $DEV_SECRET | base64 --decode >> $DEV_SECRET_DIR/$DEV_SECRET_DIR_FILE_NAME
+
+      # application-slack.yml
+      - name: Copy Slack Secret
+        env:
+          DEV_SECRET: ${{ secrets.APPLICATION_SLACK_YML }}
+          DEV_SECRET_DIR: src/main/resources
+          DEV_SECRET_DIR_FILE_NAME: application-slack.yml
         run: echo $DEV_SECRET | base64 --decode >> $DEV_SECRET_DIR/$DEV_SECRET_DIR_FILE_NAME
 
       # ./gradlew 권한 설정

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ application-prod.yml
 application-oauth.yml
 application-jwt.yml
 application-s3.yml
+application-slack.yml

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
     // Embedded Redis
     implementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
+    // Slack
+    implementation 'com.slack.api:slack-api-client:1.40.0'
+
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }

--- a/src/main/java/com/wegotoo/WegotooApplication.java
+++ b/src/main/java/com/wegotoo/WegotooApplication.java
@@ -5,8 +5,10 @@ import com.wegotoo.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WegotooApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/wegotoo/config/RabbitMQConfig.java
+++ b/src/main/java/com/wegotoo/config/RabbitMQConfig.java
@@ -16,6 +16,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -93,6 +94,9 @@ public class RabbitMQConfig {
         connectionFactory.setUsername(username);
         connectionFactory.setPassword(password);
 
+        connectionFactory.setPublisherConfirmType(ConfirmType.CORRELATED);
+        connectionFactory.setPublisherReturns(true);
+
         return connectionFactory;
     }
 
@@ -103,6 +107,7 @@ public class RabbitMQConfig {
         rabbitTemplate.setMessageConverter(messageConverter);
         rabbitTemplate.setExchange(MAIN_EXCHANGE_NAME);
         rabbitTemplate.setRoutingKey(MAIN_ROUTING_KEY);
+        rabbitTemplate.setMandatory(true);
 
         return rabbitTemplate;
     }

--- a/src/main/java/com/wegotoo/infra/mq/MessageHeaderAccessor.java
+++ b/src/main/java/com/wegotoo/infra/mq/MessageHeaderAccessor.java
@@ -1,0 +1,40 @@
+package com.wegotoo.infra.mq;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessageHeaderAccessor {
+    private static final String PUBLISH_RETRY_COUNT = "publish-retry-count";
+    private static final String RETURNED_CORRELATION_ID = "spring_returned_message_correlation";
+
+    public int getPublishRetryCount(Message message) {
+        MessageProperties messageProperties = message.getMessageProperties();
+        Object publishRetryCount = messageProperties.getHeader(PUBLISH_RETRY_COUNT);
+
+        if (publishRetryCount instanceof Integer) {
+            return (Integer) publishRetryCount;
+        }
+
+        return 0;
+    }
+
+    public String getReturnedCorrelationId(Message message) {
+        return message.getMessageProperties().getHeader(RETURNED_CORRELATION_ID);
+    }
+
+    public void addPublishRetryCountHeader(Message message, int retryCount) {
+        addHeader(message, PUBLISH_RETRY_COUNT, retryCount);
+    }
+
+    public void addCorrelationId(Message message) {
+        String correlationId = getReturnedCorrelationId(message);
+        message.getMessageProperties().setCorrelationId(correlationId);
+    }
+
+    public void addHeader(Message message, String headerName, Object value) {
+        message.getMessageProperties().setHeader(headerName, value);
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/RabbitProducer.java
+++ b/src/main/java/com/wegotoo/infra/mq/RabbitProducer.java
@@ -1,0 +1,96 @@
+package com.wegotoo.infra.mq;
+
+import com.wegotoo.infra.mq.domain.NonAckedMessage;
+import com.wegotoo.infra.mq.domain.PublishMessage;
+import com.wegotoo.infra.mq.domain.store.NonAckedMessages;
+import com.wegotoo.infra.mq.domain.store.OutStandingConfirms;
+import com.wegotoo.infra.mq.domain.store.ReturnedMessages;
+import com.wegotoo.infra.slack.SlackProducer;
+import jakarta.annotation.PostConstruct;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.ReturnedMessage;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RabbitProducer implements RabbitTemplate.ConfirmCallback, RabbitTemplate.ReturnsCallback {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final MessageHeaderAccessor messageHeaderAccessor;
+    private final OutStandingConfirms outStandingConfirms;
+    private final NonAckedMessages nonAckedMessages;
+    private final ReturnedMessages returnedMessages;
+    private final SlackProducer slackProducer;
+
+    private static final int PUBLISHER_MAX_RETRIES = 3;
+
+    @PostConstruct
+    public void init() {
+        rabbitTemplate.setConfirmCallback(this);
+        rabbitTemplate.setReturnsCallback(this);
+    }
+
+    public void send(PublishMessage message) {
+        String messageId = message.getMessageId();
+        String correlationId = UUID.randomUUID().toString();
+
+        outStandingConfirms.add(correlationId, message);
+        rabbitTemplate.convertAndSend(message, m -> {
+            m.getMessageProperties().setMessageId(messageId);
+            m.getMessageProperties().setCorrelationId(correlationId);
+            return m;
+        }, new CorrelationData(correlationId));
+    }
+
+    public void send(PublishMessage message, String correlationId, int retryCount) {
+        outStandingConfirms.add(correlationId, message);
+        rabbitTemplate.convertAndSend(message, m -> {
+            messageHeaderAccessor.addCorrelationId(m);
+            messageHeaderAccessor.addPublishRetryCountHeader(m, retryCount);
+            return m;
+        }, NonAckedMessage.of(correlationId, retryCount));
+    }
+
+    public void send(Message message) {
+        PublishMessage publishMessage = (PublishMessage) rabbitTemplate.getMessageConverter().fromMessage(message);
+        String correlationId = messageHeaderAccessor.getReturnedCorrelationId(message);
+        int retryCount = messageHeaderAccessor.getPublishRetryCount(message);
+
+        outStandingConfirms.add(correlationId, publishMessage);
+        rabbitTemplate.correlationConvertAndSend(message, NonAckedMessage.of(correlationId, retryCount));
+    }
+
+    @Override
+    public void confirm(CorrelationData correlationData, boolean ack, String cause) {
+        if (ack) {
+            outStandingConfirms.remove(correlationData.getId());
+        } else {
+            if (correlationData instanceof NonAckedMessage nonAckedMessage) {
+                nonAckedMessages.add(correlationData.getId(), nonAckedMessage.getRetryCount());
+            } else {
+                nonAckedMessages.add(correlationData.getId(), 0);
+            }
+        }
+    }
+
+    @Override
+    public void returnedMessage(ReturnedMessage returned) {
+        Message message = returned.getMessage();
+        int publisherRetryCount = messageHeaderAccessor.getPublishRetryCount(message);
+
+        if (publisherRetryCount >= PUBLISHER_MAX_RETRIES) {
+            slackProducer.sendMessage(message);
+            return;
+        }
+
+        messageHeaderAccessor.addCorrelationId(message);
+        messageHeaderAccessor.addPublishRetryCountHeader(message, publisherRetryCount + 1);
+
+        returnedMessages.add(message);
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/NonAckedMessage.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/NonAckedMessage.java
@@ -1,0 +1,25 @@
+package com.wegotoo.infra.mq.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+
+@Getter
+public class NonAckedMessage extends CorrelationData {
+
+    private int retryCount;
+
+    @Builder
+    private NonAckedMessage(String correlationId, int retryCount) {
+        super(correlationId);
+        this.retryCount = retryCount;
+    }
+
+    public static NonAckedMessage of(String correlationId, int retryCount) {
+        return NonAckedMessage.builder()
+                .correlationId(correlationId)
+                .retryCount(retryCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/NotificationPublishMessage.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/NotificationPublishMessage.java
@@ -1,0 +1,51 @@
+package com.wegotoo.infra.mq.domain;
+
+import com.wegotoo.application.notification.event.NotificationEvent;
+import com.wegotoo.domain.notification.Notification;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationPublishMessage implements PublishMessage {
+
+    private Long id;
+    private Long fromId;
+    private Long toId;
+    private String fromName;
+    private String toName;
+    private String event;
+    private String message;
+
+    @Builder
+    private NotificationPublishMessage(Long id, Long fromId, Long toId, String fromName, String toName, String event,
+                                      String message) {
+        this.id = id;
+        this.fromId = fromId;
+        this.toId = toId;
+        this.fromName = fromName;
+        this.toName = toName;
+        this.event = event;
+        this.message = message;
+    }
+
+    public NotificationPublishMessage of(Notification notification, NotificationEvent event) {
+        return NotificationPublishMessage.builder()
+                .id(notification.getId())
+                .fromId(event.getFromId())
+                .toId(event.getToId())
+                .fromName(event.getFromName())
+                .toName(event.getToName())
+                .event(event.getEvent())
+                .message(event.getMessage())
+                .build();
+    }
+
+    @Override
+    public String getMessageId() {
+        return String.format("notification:%s", id);
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/PublishMessage.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/PublishMessage.java
@@ -1,0 +1,6 @@
+package com.wegotoo.infra.mq.domain;
+
+public interface PublishMessage {
+    String getMessageId();
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/store/NonAckedMessages.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/store/NonAckedMessages.java
@@ -1,0 +1,25 @@
+package com.wegotoo.infra.mq.domain.store;
+
+import com.wegotoo.infra.mq.domain.NonAckedMessage;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NonAckedMessages {
+
+    private final Queue<NonAckedMessage> nonAckedMessages = new ConcurrentLinkedQueue<>();
+
+    public void add(String correlationId, int retryCount) {
+        nonAckedMessages.add(NonAckedMessage.of(correlationId, retryCount));
+    }
+
+    public NonAckedMessage remove() {
+        return nonAckedMessages.poll();
+    }
+
+    public boolean isEmpty() {
+        return nonAckedMessages.isEmpty();
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/store/OutStandingConfirms.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/store/OutStandingConfirms.java
@@ -1,0 +1,20 @@
+package com.wegotoo.infra.mq.domain.store;
+
+import com.wegotoo.infra.mq.domain.PublishMessage;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OutStandingConfirms {
+
+    private final ConcurrentHashMap<String, PublishMessage> outstandingConfirms = new ConcurrentHashMap<>();
+
+    public void add(String correlationId, PublishMessage message) {
+        outstandingConfirms.put(correlationId, message);
+    }
+
+    public PublishMessage remove(String correlationId) {
+        return outstandingConfirms.remove(correlationId);
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/domain/store/ReturnedMessages.java
+++ b/src/main/java/com/wegotoo/infra/mq/domain/store/ReturnedMessages.java
@@ -1,0 +1,25 @@
+package com.wegotoo.infra.mq.domain.store;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.springframework.amqp.core.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReturnedMessages {
+
+    private final Queue<Message> returnedMessages = new ConcurrentLinkedQueue<>();
+
+    public void add(Message message) {
+        returnedMessages.add(message);
+    }
+
+    public Message remove() {
+        return returnedMessages.poll();
+    }
+
+    public boolean isEmpty() {
+        return returnedMessages.isEmpty();
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/scheduler/NonAckedMessagesScheduler.java
+++ b/src/main/java/com/wegotoo/infra/mq/scheduler/NonAckedMessagesScheduler.java
@@ -1,0 +1,50 @@
+package com.wegotoo.infra.mq.scheduler;
+
+import com.wegotoo.infra.mq.RabbitProducer;
+import com.wegotoo.infra.mq.domain.NonAckedMessage;
+import com.wegotoo.infra.mq.domain.PublishMessage;
+import com.wegotoo.infra.mq.domain.store.NonAckedMessages;
+import com.wegotoo.infra.mq.domain.store.OutStandingConfirms;
+import com.wegotoo.infra.slack.SlackProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NonAckedMessagesScheduler {
+
+    private final RabbitProducer rabbitProducer;
+    private final OutStandingConfirms outStandingConfirms;
+    private final NonAckedMessages nonAckedMessages;
+    private final SlackProducer slackProducer;
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 5000)
+    public void scheduleNonAckedMessages() {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            if (nonAckedMessages.isEmpty()) {
+                break;
+            }
+
+            NonAckedMessage nonAckedMessage = nonAckedMessages.remove();
+            tryRepublish(nonAckedMessage.getId(), nonAckedMessage.getRetryCount());
+        }
+    }
+
+    private void tryRepublish(String correlationId, int retryCount) {
+        PublishMessage publishMessage = outStandingConfirms.remove(correlationId);
+
+        if (publishMessage == null) {
+            return;
+        }
+
+        if (retryCount >= 3) {
+            slackProducer.sendMessage(publishMessage);
+            return;
+        }
+
+        rabbitProducer.send(publishMessage, correlationId, retryCount + 1);
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/mq/scheduler/ReturnedMessageScheduler.java
+++ b/src/main/java/com/wegotoo/infra/mq/scheduler/ReturnedMessageScheduler.java
@@ -1,0 +1,32 @@
+package com.wegotoo.infra.mq.scheduler;
+
+import com.wegotoo.infra.mq.RabbitProducer;
+import com.wegotoo.infra.mq.domain.store.ReturnedMessages;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReturnedMessageScheduler {
+
+    private final RabbitProducer rabbitProducer;
+    private final ReturnedMessages returnedMessages;
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 5000)
+    public void scheduleReturnedMessages() {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            if (returnedMessages.isEmpty()) {
+                break;
+            }
+
+            Message message = returnedMessages.remove();
+            rabbitProducer.send(message);
+        }
+    }
+
+}

--- a/src/main/java/com/wegotoo/infra/security/util/RabbitMQProperties.java
+++ b/src/main/java/com/wegotoo/infra/security/util/RabbitMQProperties.java
@@ -10,5 +10,6 @@ public class RabbitMQProperties {
     public static final String DLX_NAME = "app.sse.error";
     public static final String DLQ_NAME = "app.sse.queue.dead";
     public static final String DLQ_ROUTING_KEY = "sse.dead";
+    public static final String PUBLISHER_RETRY_EXCHANGE = "publish.retry.delayed";
 
 }

--- a/src/main/java/com/wegotoo/infra/slack/SlackProducer.java
+++ b/src/main/java/com/wegotoo/infra/slack/SlackProducer.java
@@ -1,0 +1,56 @@
+package com.wegotoo.infra.slack;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slack.api.Slack;
+import com.slack.api.webhook.Payload;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackProducer {
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+    private final Slack slack = Slack.getInstance();
+    private final ObjectMapper om;
+    private final MessageConverter messageConverter;
+
+    public void sendMessage(Message message) {
+        Object content = messageConverter.fromMessage(message);
+        sendMessage(content);
+    }
+
+    public void sendMessage(Object obj) {
+        String jsonMessage = convertMessageToJson(obj);
+        String slackMessage = createAlertMessage(jsonMessage);
+
+        Payload payload = Payload.builder()
+                .text(slackMessage)
+                .build();
+
+        try {
+            slack.send(webhookUrl, payload);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Slack 알림 전송 실패");
+        }
+    }
+
+    private String convertMessageToJson(Object obj) {
+        try {
+            return om.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            return "메세지 JSON 변환 실패";
+        }
+    }
+
+    private String createAlertMessage(String message) {
+        return String.format("🚨 전송 실패 수신 🚨\n전송 처리에 실패한 메시지가 있습니다.\n\n```\n%s\n```", message);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,4 @@ spring:
       - jwt
       - oauth
       - s3
+      - slack

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,3 +9,4 @@ spring:
       - jwt
       - oauth
       - s3
+      - slack


### PR DESCRIPTION
## 💡 연관된 이슈
close #108 

## 📝 작업 내용
1. 슬랙(Slack) 연동
    * `RabbitMQ`에서 전송 시에 발생하는 에러에 대한 알림을 받기 위해 슬랙(Slack) 연동
    * `slack-api-client` 의존성을 추가하고, 관련 설정 반영

2. `RabbitMQ` 메세지 전송 안정성 강화
    * `RabbitMQ` 메세지 전송 실패에 대응하고 데이터 유실을 방지하기 위한 로직 구현
        * `Publisher Confirms/Returns`: `ConfirmCallback`, `Returns Callback`을 구현하여 메세지 전송 실패를 감지
            * `Confirm(NACK)`: 브로커 미도착 메세지는 `NonAckedMessages`에 저장
            * `Return`: 라우팅 실패 메세지는 `ReturnedMessages`에 저장
        * 실패 메세지 저장: 전송에 실패한 메세지는 재시도를 위해 `In-Memory`에 저장됩니다. 
        * 최대 재시도 및 슬랙 알림: 최대 재전송 횟수 3회만큼 재시도 후, `SlackProducer`를 통해 슬랙으로 에러 알림을 전송

## 💬 리뷰 요구 사항